### PR TITLE
Add arbitrary file transfer with adaptive compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Decimen Optical Transfer: fountain-coded QR file transfer
+# Decimen Optical Transfer: fountain-coded QR file and note transfer
 
 Send a file between two devices using nothing but a **screen and a camera**.
 One page displays the file as an endless stream of animated QR codes; another
@@ -12,6 +12,8 @@ multi-code grids, and an error-corrected color channel. This version accepts
 arbitrary files up to 64 MB, preserves their filename and media type inside
 the fountain stream, adaptively uses gzip only when it shrinks the optical
 payload, and verifies SHA-256 before offering the received file for download.
+It also has a separate private-note flow: received notes are verified,
+deduplicated, and kept only in that browser's local storage.
 
 <p align="center">
   <img src="docs/receiving.jpg" width="420"
@@ -34,6 +36,9 @@ npm run dev
   tap **Start camera**, and point it at the code.
 - When recovery completes, save the received file after its SHA-256 check
   passes.
+- For text, use `https://localhost:5173/notes/send/` and open
+  `/notes/receive/` on the other device. Received notes appear in a local
+  message panel and never leave that browser unless you copy or delete them.
 
 **Why the dev server is https-only:** the receiver uses `getUserMedia`, and
 browsers remove that API entirely on insecure origins: a phone reaching

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ mean dropped frames, which the fountain happily absorbs.
 - **Progress bars must track frames collected, not blocks solved.** LT
   peeling back-loads its solve cascade: block-count progress looks stalled
   for most of the transfer, then teleports to 100%. The receiver estimates
-  remaining time from its observed unique-frame rate.
+  remaining time from its observed unique-frame rate, fills toward the hard
+  minimum of K frames, then holds at 99% until decoding actually completes.
 - **QR error correction is set to the minimum (L).** In-frame ECC and the
   fountain layer solve different problems (corruption vs erasure), but at
   these frame sizes level L plus frame disposal is the better trade.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ The payload travels as light.
 
 This is a minimal proof of concept extracted from a larger
 experiment that reached **128 KB/s phone-to-phone** with denser frames,
-multi-code grids, and an error-corrected color channel. This PoC keeps only
-the essential trick and transmits a 512 KB image (or a 2 MB one, selectable
-in the sender's settings) at a comfortable rate.
+multi-code grids, and an error-corrected color channel. This version accepts
+arbitrary files up to 64 MB, preserves their filename and media type inside
+the fountain stream, adaptively uses gzip only when it shrinks the optical
+payload, and verifies SHA-256 before offering the received file for download.
 
 <p align="center">
   <img src="docs/receiving.jpg" width="420"
@@ -26,13 +27,13 @@ npm run dev
 ```
 
 - On the **sending** device (a laptop is ideal): open
-  `https://localhost:5173/send/` and it starts streaming immediately. Max
+  `https://localhost:5173/send/`, choose a file, and it starts streaming. Max
   screen brightness helps.
 - On the **receiving** device (a phone): open the `Network` URL Vite prints
   (`https://<lan-ip>:5173/receive/`), accept the certificate warning once,
   tap **Start camera**, and point it at the code.
-- A few seconds later: *Transfer Complete!* and the received image, verified
-  by hash.
+- When recovery completes, save the received file after its SHA-256 check
+  passes.
 
 **Why the dev server is https-only:** the receiver uses `getUserMedia`, and
 browsers remove that API entirely on insecure origins: a phone reaching

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ mean dropped frames, which the fountain happily absorbs.
   zombie capture loop.
 - **Progress bars must track frames collected, not blocks solved.** LT
   peeling back-loads its solve cascade: block-count progress looks stalled
-  for most of the transfer, then teleports to 100%.
+  for most of the transfer, then teleports to 100%. The receiver estimates
+  remaining time from its observed unique-frame rate.
 - **QR error correction is set to the minimum (L).** In-frame ECC and the
   fountain layer solve different problems (corruption vs erasure), but at
   these frame sizes level L plus frame disposal is the better trade.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ mean dropped frames, which the fountain happily absorbs.
 - **Progress bars must track frames collected, not blocks solved.** LT
   peeling back-loads its solve cascade: block-count progress looks stalled
   for most of the transfer, then teleports to 100%. The receiver estimates
-  remaining time from its observed unique-frame rate, fills toward the hard
-  minimum of K frames, then holds at 99% until decoding actually completes.
+  remaining time from its observed unique-frame rate. A hybrid of incoming
+  frames and actually decoded blocks keeps the bar moving through redundancy;
+  only verified completion reaches 100%.
 - **QR error correction is set to the minimum (L).** In-frame ECC and the
   fountain layer solve different problems (corruption vs erasure), but at
   these frame sizes level L plus frame disposal is the better trade.

--- a/index.html
+++ b/index.html
@@ -9,15 +9,15 @@
   <body>
     <h1>DECIMEN <small>— Fountain QR File Transfer (PoC)</small></h1>
     <p class="hint">
-      Send a file between two devices using nothing but a screen and a camera.
-      Open <a href="./send/">send</a> on the device with the file (a laptop is
-      ideal) and <a href="./receive/">receive</a> on a phone, then point the
-      phone's camera at the flickering code.
+      Send any file up to 64 MB between two devices using nothing but a screen
+      and a camera. Open <a href="./send/">send</a> on the device with the file
+      and <a href="./receive/">receive</a> on a phone, then point the phone's
+      camera at the flickering code.
     </p>
     <p class="hint">
-      No network path between the devices is used — the payload travels as
-      light. Fountain coding means the receiver can drop any frames, in any
-      order, and still reconstruct the file.
+      No network path between the devices is used. Files are compressed when
+      that shortens the transfer; the original filename and media type travel
+      inside the fountain stream, and SHA-256 is verified before download.
     </p>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,18 +6,55 @@
     <title>Optical Transfer — fountain-coded QR file transfer</title>
     <link rel="stylesheet" href="./shared/style.css" />
   </head>
-  <body>
-    <h1>DECIMEN <small>— Fountain QR File Transfer (PoC)</small></h1>
-    <p class="hint">
-      Send any file up to 64 MB between two devices using nothing but a screen
-      and a camera. Open <a href="./send/">send</a> on the device with the file
-      and <a href="./receive/">receive</a> on a phone, then point the phone's
-      camera at the flickering code.
-    </p>
-    <p class="hint">
-      No network path between the devices is used. Files are compressed when
-      that shortens the transfer; the original filename and media type travel
-      inside the fountain stream, and SHA-256 is verified before download.
-    </p>
+  <body class="home-page">
+    <header class="site-header">
+      <a class="brand" href="./">DECIMEN</a>
+      <span class="header-note">Screen to camera. Nothing uploaded.</span>
+    </header>
+    <main class="home-shell">
+      <section class="hero">
+        <p class="eyebrow">Offline optical transfer</p>
+        <h1>Move it without<br />putting it online.</h1>
+        <p class="hero-copy">
+          Send files or private notes from one screen to another device's camera.
+          No account, pairing, cloud storage, or network path between devices.
+        </p>
+      </section>
+
+      <section class="transfer-grid" aria-label="Choose a transfer type">
+        <article class="transfer-card file-card">
+          <div class="card-number">01</div>
+          <div>
+            <p class="card-kicker">Files</p>
+            <h2>Any file, up to 64 MB</h2>
+            <p>Compressed when useful, restored with its original name, then verified before download.</p>
+          </div>
+          <div class="card-actions">
+            <a class="action primary" href="./send/">Send a file <span>→</span></a>
+            <a class="action" href="./receive/">Receive <span>↙</span></a>
+          </div>
+        </article>
+
+        <article class="transfer-card note-feature-card">
+          <div class="card-number">02</div>
+          <div>
+            <p class="card-kicker">Private notes</p>
+            <h2>Text that stays on the device</h2>
+            <p>Scan a note and it becomes a local message—saved only in the receiving browser.</p>
+          </div>
+          <div class="card-actions">
+            <a class="action primary" href="./notes/send/">Send a note <span>→</span></a>
+            <a class="action" href="./notes/receive/">Receive &amp; view notes <span>↙</span></a>
+          </div>
+        </article>
+      </section>
+
+      <section class="how-it-works" aria-label="How it works">
+        <span>Pick or write</span><i></i><span>Show the animated code</span><i></i><span>Scan and recover</span>
+      </section>
+      <p class="privacy-note">
+        Transfers are visible to a camera pointed at the code. Decimen does not upload or relay their contents.
+      </p>
+    </main>
   </body>
 </html>

--- a/notes/receive/index.html
+++ b/notes/receive/index.html
@@ -2,26 +2,23 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
-    />
-    <title>Optical Transfer — receive</title>
-    <link rel="stylesheet" href="../shared/style.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no" />
+    <title>Decimen — receive private notes</title>
+    <link rel="stylesheet" href="../../shared/style.css" />
   </head>
-  <body class="receiver-page" data-transfer-mode="file">
+  <body class="receiver-page note-page" data-transfer-mode="note">
     <header class="site-header">
-      <a class="brand" href="../">DECIMEN</a>
-      <span class="mode-badge">Receive file</span>
+      <a class="brand" href="../../">DECIMEN</a>
+      <span class="mode-badge">Receive notes</span>
     </header>
-    <main class="receiver-shell">
+    <main class="receiver-shell notes-receiver-shell">
       <section class="receiver-primary">
         <div class="receiver-heading">
           <div>
-            <p class="eyebrow">Camera → device</p>
-            <h1>Receive a file</h1>
+            <p class="eyebrow">Private notes · camera → device</p>
+            <h1>Receive a note</h1>
           </div>
-          <div class="hint status-line" id="stats">Ready to scan a file stream</div>
+          <div class="hint status-line" id="stats">Ready to scan a note stream</div>
         </div>
         <details class="settings" id="settings">
           <summary>Camera settings</summary>
@@ -45,16 +42,7 @@
               <strong id="progress-label">0% · 0 frames</strong>
               <span id="eta-label">Estimating time…</span>
             </div>
-            <div
-              class="progress"
-              id="progress"
-              style="display: none"
-              role="progressbar"
-              aria-label="File recovery progress"
-              aria-valuemin="0"
-              aria-valuemax="100"
-              aria-valuenow="0"
-            ><div id="bar"></div></div>
+            <div class="progress" id="progress" style="display: none" role="progressbar" aria-label="Note recovery progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div id="bar"></div></div>
           </div>
         </div>
         <div id="result"></div>
@@ -72,7 +60,19 @@
           </div>
         </details>
       </section>
+
+      <section class="notes-panel" aria-labelledby="saved-notes-heading">
+        <div class="notes-panel-heading">
+          <div>
+            <p class="eyebrow">This browser only</p>
+            <h2 id="saved-notes-heading">Saved notes</h2>
+          </div>
+          <button class="text-button danger" id="clear-notes" type="button">Clear all</button>
+        </div>
+        <p class="notes-empty" id="notes-empty">Received notes will appear here and remain on this device.</p>
+        <div class="notes-list" id="notes-list"></div>
+      </section>
     </main>
-    <script type="module" src="./main.ts"></script>
+    <script type="module" src="../../receive/main.ts"></script>
   </body>
 </html>

--- a/notes/send/index.html
+++ b/notes/send/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Decimen — send a private note</title>
+    <link rel="stylesheet" href="../../shared/style.css" />
+  </head>
+  <body class="tool-page note-page" data-transfer-mode="note">
+    <header class="site-header">
+      <a class="brand" href="../../">DECIMEN</a>
+      <span class="mode-badge">Send note</span>
+    </header>
+    <main class="send-shell">
+      <section class="tool-intro">
+        <p class="eyebrow">Private notes · screen → camera</p>
+        <h1>Send a note</h1>
+        <p>The note becomes an animated code on this screen. It is never uploaded.</p>
+      </section>
+      <label class="note-composer">
+        <span>Your note</span>
+        <textarea id="note-text" rows="7" maxlength="262144" placeholder="Write something for the other device…" autofocus></textarea>
+      </label>
+      <button id="send-note" type="button">Start note stream</button>
+      <div class="hint status-line" id="specs">Write a note to begin</div>
+      <details class="settings">
+        <summary>Transfer settings</summary>
+        <div class="row">
+          <label>tx fps
+            <select id="cfg-fps"><option>10</option><option>15</option><option>20</option><option selected>24</option><option>30</option><option>60</option></select>
+          </label>
+          <label>bytes / frame
+            <select id="cfg-bytes"><option>500</option><option selected>1000</option><option>1465</option><option>1850</option><option>2331</option><option>2953</option></select>
+          </label>
+          <label>error correction
+            <select id="cfg-ecc"><option selected>L</option><option>M</option><option>Q</option><option>H</option></select>
+          </label>
+          <label>display size
+            <input id="cfg-size" type="range" min="300" max="1200" step="50" value="900" />
+          </label>
+        </div>
+      </details>
+      <div class="stage" id="stage" hidden><canvas id="qr" width="16" height="16"></canvas></div>
+      <div class="hint footer-hint">
+        Open <a href="../receive/">Receive notes</a> on the other device and point its camera here.
+      </div>
+    </main>
+    <script type="module" src="../../send/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,14 @@
     "": {
       "name": "decimen-optical-transfer",
       "version": "0.1.0",
+      "dependencies": {
+        "fflate": "0.8.3"
+      },
       "devDependencies": {
         "@types/qrcode": "^1.5.5",
         "@vitejs/plugin-basic-ssl": "^1.2.0",
         "qrcode": "^1.5.4",
+        "tsx": "4.20.6",
         "typescript": "^5.5.0",
         "vite": "^6.0.0",
         "zxing-wasm": "^2.0.0"
@@ -1046,6 +1050,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1083,6 +1093,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -1270,6 +1293,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
@@ -1388,6 +1421,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,19 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --import tsx --test tests/*.test.ts"
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.5",
     "@vitejs/plugin-basic-ssl": "^1.2.0",
     "qrcode": "^1.5.4",
+    "tsx": "4.20.6",
     "typescript": "^5.5.0",
     "vite": "^6.0.0",
     "zxing-wasm": "^2.0.0"
+  },
+  "dependencies": {
+    "fflate": "0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "license": "MIT",
-  "description": "Proof of concept: file transfer between two devices using fountain-coded animated QR codes — screen to camera, no network.",
+  "description": "Offline file and private-note transfer using fountain-coded animated QR codes — screen to camera, no network.",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/receive/index.html
+++ b/receive/index.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <h1>DECIMEN <small>— Fountain QR File Transfer</small></h1>
-    <div class="hint" id="stats">point the camera at the sender's code</div>
+    <div class="hint" id="stats">point the camera at a Decimen file stream</div>
     <details class="settings" id="settings">
       <summary>Settings</summary>
       <div class="row">
@@ -54,7 +54,7 @@
       <div class="metric"><div class="k">frames new/dup</div><div class="v" id="m-frames">—</div></div>
       <div class="metric"><div class="k">blocks K</div><div class="v" id="m-k">—</div></div>
       <div class="metric"><div class="k">block len</div><div class="v" id="m-block">—</div></div>
-      <div class="metric"><div class="k">payload</div><div class="v" id="m-payload">—</div></div>
+      <div class="metric"><div class="k">transfer</div><div class="v" id="m-payload">—</div></div>
     </div>
     <div class="preview" id="preview" style="display: none">
       <video id="video" muted playsinline></video>

--- a/receive/index.html
+++ b/receive/index.html
@@ -59,7 +59,20 @@
     <div class="preview" id="preview" style="display: none">
       <video id="video" muted playsinline></video>
     </div>
-    <div class="progress" id="progress" style="display: none"><div id="bar"></div></div>
+    <div class="progress-status" id="progress-status" style="display: none" aria-live="polite">
+      <strong id="progress-label">0% · 0 frames</strong>
+      <span id="eta-label">Estimating time…</span>
+    </div>
+    <div
+      class="progress"
+      id="progress"
+      style="display: none"
+      role="progressbar"
+      aria-label="File recovery progress"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow="0"
+    ><div id="bar"></div></div>
     <div id="result"></div>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -9,7 +9,7 @@
 //   cascade, so blocks-solved looks stalled and then teleports to done.
 
 import { LTDecoder } from "../shared/fountain";
-import { fnv1a, parseFrame } from "../shared/protocol";
+import { fnv1a, parseFrame, unpackFile, verifyFile } from "../shared/protocol";
 
 const OVERHEAD_EST = 1.18; // expected frames ≈ K × this (robust-soliton ε)
 
@@ -159,26 +159,47 @@ function onDecoded(bytes: Uint8Array) {
     const payload = decoder.assemble()!;
     const seconds = (performance.now() - startTs) / 1000;
     const ok = fnv1a(payload) === header.payloadFnv;
-    finish(payload, ok, seconds, header.totalLen);
+    void finish(payload, ok, seconds);
   }
 }
 
-function finish(payload: Uint8Array, hashOk: boolean, seconds: number, totalLen: number) {
+async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
   done = true;
   captureGen++;
   stream?.getTracks().forEach((t) => t.stop());
   preview.style.display = "none";
   bar.style.width = "100%";
-  const kb = Math.round(totalLen / 1024);
-  const rate = (totalLen / 1024 / seconds).toFixed(1);
-  stats.textContent = `${kb} KB in ${seconds.toFixed(1)} s · ${rate} KB/s · hash ${hashOk ? "verified ✓" : "MISMATCH ✗"}`;
-  const heading = document.createElement("div");
-  heading.className = "done";
-  heading.textContent = "Transfer Complete!";
-  const img = document.createElement("img");
-  img.className = "received";
-  img.src = URL.createObjectURL(new Blob([payload as BlobPart], { type: "image/png" }));
-  result.append(heading, img);
+  try {
+    if (!hashOk) throw new Error("The optical stream checksum did not match.");
+    const file = await unpackFile(container);
+    if (!(await verifyFile(file))) throw new Error("The recovered file failed SHA-256 verification.");
+
+    const kb = Math.round(file.bytes.length / 1024);
+    const rate = (container.length / 1024 / seconds).toFixed(1);
+    stats.textContent =
+      `${kb} KB in ${seconds.toFixed(1)} s · ${rate} KB/s · ` +
+      `${file.compression === "gzip" ? "gzip decompressed · " : ""}SHA-256 verified ✓`;
+    const heading = document.createElement("div");
+    heading.className = "done";
+    heading.textContent = "Transfer Complete!";
+    const url = URL.createObjectURL(new Blob([file.bytes as BlobPart], { type: file.type }));
+    const download = document.createElement("a");
+    download.className = "download";
+    download.href = url;
+    download.download = file.name;
+    download.textContent = `Save ${file.name}`;
+    result.replaceChildren(heading, download);
+    if (file.type.startsWith("image/")) {
+      const image = document.createElement("img");
+      image.className = "received";
+      image.alt = `Received file preview: ${file.name}`;
+      image.src = url;
+      result.append(image);
+    }
+  } catch (error) {
+    bar.classList.add("error");
+    stats.textContent = `✗ ${error instanceof Error ? error.message : String(error)}`;
+  }
 }
 
 function updateStats() {

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -197,8 +197,7 @@ function updateProgressEstimate() {
   const shownPercent = percent < 10 ? percent.toFixed(1) : percent.toFixed(0);
   bar.style.width = `${percent.toFixed(1)}%`;
   progressEl.setAttribute("aria-valuenow", String(Math.floor(percent)));
-  progressLabel.textContent =
-    `${shownPercent}% · ${decoder.framesNew}/${estimate.targetFrames} unique frames`;
+  progressLabel.textContent = `${shownPercent}% · ${decoder.framesNew} unique frames`;
   etaLabel.textContent = estimate.finishing
     ? "Finishing recovery…"
     : estimate.etaSeconds === undefined

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -192,17 +192,23 @@ function onDecoded(bytes: Uint8Array) {
 function updateProgressEstimate() {
   if (!decoder) return;
   const elapsed = Math.max(0, (performance.now() - startTs) / 1000);
-  const estimate = estimateTransferProgress(decoder.k, decoder.framesNew, elapsed);
+  const estimate = estimateTransferProgress(
+    decoder.k,
+    decoder.framesNew,
+    elapsed,
+    decoder.solvedCount,
+  );
   const percent = estimate.fraction * 100;
   const shownPercent = percent < 10 ? percent.toFixed(1) : percent.toFixed(0);
   bar.style.width = `${percent.toFixed(1)}%`;
   progressEl.setAttribute("aria-valuenow", String(Math.floor(percent)));
-  progressLabel.textContent = `${shownPercent}% · ${decoder.framesNew} unique frames`;
-  etaLabel.textContent = estimate.finishing
-    ? "Finishing recovery…"
-    : estimate.etaSeconds === undefined
-      ? "Estimating time…"
-      : `About ${formatDuration(estimate.etaSeconds)} remaining`;
+  progressLabel.textContent =
+    `${shownPercent}% · ${decoder.solvedCount}/${decoder.k} blocks`;
+  etaLabel.textContent = estimate.etaSeconds === undefined
+    ? estimate.phase === "decoding"
+      ? `${decoder.framesNew} frames · decoding`
+      : "Estimating time…"
+    : `About ${formatDuration(estimate.etaSeconds)} · ${decoder.framesNew} frames`;
 }
 
 async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -14,8 +14,17 @@ import {
   estimateTransferProgress,
   formatDuration,
 } from "../shared/progress";
+import {
+  clearStoredNotes,
+  deleteStoredNote,
+  loadStoredNotes,
+  storeReceivedNote,
+  unpackPrivateNote,
+  type StoredNote,
+} from "../shared/notes";
 import { fnv1a, parseFrame, unpackFile, verifyFile } from "../shared/protocol";
 
+const transferMode = document.body.dataset.transferMode === "note" ? "note" : "file";
 const startBtn = document.getElementById("start") as HTMLButtonElement;
 const video = document.getElementById("video") as HTMLVideoElement;
 const preview = document.getElementById("preview")!;
@@ -28,6 +37,10 @@ const etaLabel = document.getElementById("eta-label")!;
 const result = document.getElementById("result")!;
 const settings = document.getElementById("settings") as HTMLDetailsElement;
 const metricsEl = document.getElementById("metrics")!;
+const diagnosticsEl = document.getElementById("diagnostics") as HTMLDetailsElement | null;
+const notesList = document.getElementById("notes-list");
+const notesEmpty = document.getElementById("notes-empty");
+const clearNotesBtn = document.getElementById("clear-notes") as HTMLButtonElement | null;
 const metric = (id: string) => document.getElementById(id)!;
 
 let stream: MediaStream | null = null;
@@ -43,6 +56,12 @@ const captureTimes: number[] = [];
 const decodeTimes: number[] = [];
 
 startBtn.onclick = () => void start();
+clearNotesBtn?.addEventListener("click", () => {
+  if (!window.confirm("Delete every note stored in this browser?")) return;
+  clearStoredNotes(localStorage);
+  renderStoredNotes();
+});
+if (transferMode === "note") renderStoredNotes();
 
 async function start() {
   if (!navigator.mediaDevices?.getUserMedia) {
@@ -60,6 +79,7 @@ async function start() {
   startBtn.style.display = "none";
   preview.style.display = "block";
   metricsEl.style.display = "grid";
+  if (diagnosticsEl) diagnosticsEl.style.display = "block";
   const base: MediaTrackConstraints = {
     facingMode: "environment",
     width: { ideal: captureWidth },
@@ -193,10 +213,21 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
   preview.style.display = "none";
   bar.style.width = "100%";
   progressEl.setAttribute("aria-valuenow", "100");
-  progressLabel.textContent = "100% · file recovered";
+  progressLabel.textContent = `100% · ${transferMode === "note" ? "note" : "file"} recovered`;
   etaLabel.textContent = `${formatDuration(seconds)} total`;
   try {
     if (!hashOk) throw new Error("The optical stream checksum did not match.");
+    if (transferMode === "note") {
+      const { note, file } = await unpackPrivateNote(container);
+      const stored = storeReceivedNote(localStorage, note);
+      const rate = (container.length / 1024 / seconds).toFixed(1);
+      stats.textContent =
+        `${stored.added ? "note saved" : "note already saved"} · ${seconds.toFixed(1)} s · ` +
+        `${rate} KB/s · ${file.compression === "gzip" ? "gzip · " : ""}SHA-256 verified ✓`;
+      renderStoredNotes();
+      showReceivedNote(note.text, stored.added);
+      return;
+    }
     const file = await unpackFile(container);
     if (!(await verifyFile(file))) throw new Error("The recovered file failed SHA-256 verification.");
 
@@ -224,9 +255,81 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
     }
   } catch (error) {
     bar.classList.add("error");
-    etaLabel.textContent = "Verification failed";
+    etaLabel.textContent = "Transfer failed";
     stats.textContent = `✗ ${error instanceof Error ? error.message : String(error)}`;
   }
+}
+
+function showReceivedNote(text: string, added: boolean) {
+  const heading = document.createElement("div");
+  heading.className = "done";
+  heading.textContent = added ? "Note saved" : "Note already saved";
+  const previewText = document.createElement("p");
+  previewText.className = "received-note";
+  previewText.textContent = text;
+  const another = document.createElement("button");
+  another.className = "secondary-button";
+  another.type = "button";
+  another.textContent = "Receive another note";
+  another.addEventListener("click", () => window.location.reload());
+  result.replaceChildren(heading, previewText, another);
+}
+
+function formatNoteTime(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+}
+
+function renderStoredNotes() {
+  if (!notesList || !notesEmpty) return;
+  const notes = loadStoredNotes(localStorage);
+  notesEmpty.style.display = notes.length === 0 ? "block" : "none";
+  if (clearNotesBtn) clearNotesBtn.disabled = notes.length === 0;
+  notesList.replaceChildren(...notes.map(renderStoredNote));
+}
+
+function renderStoredNote(note: StoredNote): HTMLElement {
+  const card = document.createElement("article");
+  card.className = "note-card";
+
+  const meta = document.createElement("div");
+  meta.className = "note-meta";
+  const time = document.createElement("time");
+  time.dateTime = new Date(note.receivedAt).toISOString();
+  time.textContent = `Received ${formatNoteTime(note.receivedAt)}`;
+  meta.append(time);
+
+  const text = document.createElement("p");
+  text.textContent = note.text;
+
+  const actions = document.createElement("div");
+  actions.className = "note-actions";
+  const copy = document.createElement("button");
+  copy.type = "button";
+  copy.className = "text-button";
+  copy.textContent = "Copy";
+  copy.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(note.text);
+      copy.textContent = "Copied";
+      setTimeout(() => { copy.textContent = "Copy"; }, 1500);
+    } catch {
+      copy.textContent = "Copy failed";
+    }
+  });
+  const remove = document.createElement("button");
+  remove.type = "button";
+  remove.className = "text-button danger";
+  remove.textContent = "Delete";
+  remove.addEventListener("click", () => {
+    deleteStoredNote(localStorage, note.id);
+    renderStoredNotes();
+  });
+  actions.append(copy, remove);
+  card.append(meta, text, actions);
+  return card;
 }
 
 function updateStats() {

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -9,9 +9,12 @@
 //   cascade, so blocks-solved looks stalled and then teleports to done.
 
 import { LTDecoder } from "../shared/fountain";
+import {
+  EXPECTED_FOUNTAIN_OVERHEAD,
+  estimateTransferProgress,
+  formatDuration,
+} from "../shared/progress";
 import { fnv1a, parseFrame, unpackFile, verifyFile } from "../shared/protocol";
-
-const OVERHEAD_EST = 1.18; // expected frames ≈ K × this (robust-soliton ε)
 
 const startBtn = document.getElementById("start") as HTMLButtonElement;
 const video = document.getElementById("video") as HTMLVideoElement;
@@ -19,6 +22,9 @@ const preview = document.getElementById("preview")!;
 const stats = document.getElementById("stats")!;
 const progressEl = document.getElementById("progress")!;
 const bar = document.getElementById("bar")!;
+const progressStatus = document.getElementById("progress-status")!;
+const progressLabel = document.getElementById("progress-label")!;
+const etaLabel = document.getElementById("eta-label")!;
 const result = document.getElementById("result")!;
 const settings = document.getElementById("settings") as HTMLDetailsElement;
 const metricsEl = document.getElementById("metrics")!;
@@ -150,10 +156,10 @@ function onDecoded(bytes: Uint8Array) {
     sessionId = header.sessionId;
     startTs = performance.now();
     progressEl.style.display = "block";
+    progressStatus.style.display = "flex";
   }
   decoder.addFrame(header.seq, block);
-  const progress = Math.min(0.99, decoder.framesNew / (decoder.k * OVERHEAD_EST));
-  bar.style.width = `${(progress * 100).toFixed(1)}%`;
+  updateProgressEstimate();
 
   if (decoder.isComplete) {
     const payload = decoder.assemble()!;
@@ -163,12 +169,32 @@ function onDecoded(bytes: Uint8Array) {
   }
 }
 
+function updateProgressEstimate() {
+  if (!decoder) return;
+  const elapsed = Math.max(0, (performance.now() - startTs) / 1000);
+  const estimate = estimateTransferProgress(decoder.k, decoder.framesNew, elapsed);
+  const percent = estimate.fraction * 100;
+  const shownPercent = percent < 10 ? percent.toFixed(1) : percent.toFixed(0);
+  bar.style.width = `${percent.toFixed(1)}%`;
+  progressEl.setAttribute("aria-valuenow", String(Math.floor(percent)));
+  progressLabel.textContent =
+    `${shownPercent}% · ${decoder.framesNew}/${estimate.targetFrames} unique frames`;
+  etaLabel.textContent = estimate.finishing
+    ? "Finishing recovery…"
+    : estimate.etaSeconds === undefined
+      ? "Estimating time…"
+      : `About ${formatDuration(estimate.etaSeconds)} remaining`;
+}
+
 async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
   done = true;
   captureGen++;
   stream?.getTracks().forEach((t) => t.stop());
   preview.style.display = "none";
   bar.style.width = "100%";
+  progressEl.setAttribute("aria-valuenow", "100");
+  progressLabel.textContent = "100% · file recovered";
+  etaLabel.textContent = `${formatDuration(seconds)} total`;
   try {
     if (!hashOk) throw new Error("The optical stream checksum did not match.");
     const file = await unpackFile(container);
@@ -198,6 +224,7 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
     }
   } catch (error) {
     bar.classList.add("error");
+    etaLabel.textContent = "Verification failed";
     stats.textContent = `✗ ${error instanceof Error ? error.message : String(error)}`;
   }
 }
@@ -214,7 +241,12 @@ function updateStats() {
   metric("m-dec").textContent = (decodeTimes.length / 2).toFixed(1);
   if (!decoder) return;
   const elapsed = (now - startTs) / 1000;
-  const kbs = (decoder.framesNew * decoder.blockLen) / OVERHEAD_EST / 1024 / Math.max(0.1, elapsed);
+  updateProgressEstimate();
+  const kbs =
+    (decoder.framesNew * decoder.blockLen) /
+    EXPECTED_FOUNTAIN_OVERHEAD /
+    1024 /
+    Math.max(0.1, elapsed);
   metric("m-rate").textContent = `${kbs.toFixed(1)} KB/s`;
   metric("m-time").textContent = `${elapsed.toFixed(0)} s`;
   metric("m-frames").textContent = `${decoder.framesNew}/${decoder.framesDup}`;

--- a/send/index.html
+++ b/send/index.html
@@ -6,62 +6,56 @@
     <title>Optical Transfer — send</title>
     <link rel="stylesheet" href="../shared/style.css" />
   </head>
-  <body>
-    <h1>DECIMEN <small>— Fountain QR File Transfer</small></h1>
-    <div class="hint" id="specs">choose a file to begin</div>
-    <label class="file-picker">
-      <span>Choose any file · up to 64 MB</span>
-      <input id="cfg-file" type="file" />
-    </label>
-    <details class="settings">
-      <summary>Settings</summary>
-      <div class="row">
-        <label>
-          tx fps
-          <select id="cfg-fps">
-            <option>10</option>
-            <option>15</option>
-            <option>20</option>
-            <option selected>24</option>
-            <option>30</option>
-            <option>60</option>
-          </select>
-        </label>
-        <label>
-          bytes / frame
-          <select id="cfg-bytes">
-            <option>500</option>
-            <option>1000</option>
-            <option selected>1465</option>
-            <option>1850</option>
-            <option>2331</option>
-            <option>2953</option>
-          </select>
-        </label>
-        <label>
-          error correction
-          <select id="cfg-ecc">
-            <option selected>L</option>
-            <option>M</option>
-            <option>Q</option>
-            <option>H</option>
-          </select>
-        </label>
-        <label>
-          display size
-          <input id="cfg-size" type="range" min="300" max="1200" step="50" value="900" />
-        </label>
+  <body class="tool-page" data-transfer-mode="file">
+    <header class="site-header">
+      <a class="brand" href="../">DECIMEN</a>
+      <span class="mode-badge">Send file</span>
+    </header>
+    <main class="send-shell">
+      <section class="tool-intro">
+        <p class="eyebrow">Screen → camera</p>
+        <h1>Send a file</h1>
+        <p>Choose a file and this screen becomes the transmitter. Nothing is uploaded.</p>
+      </section>
+      <div class="hint status-line" id="specs">Choose a file to begin</div>
+      <label class="file-picker">
+        <span>Any file · up to 64 MB</span>
+        <input id="cfg-file" type="file" />
+      </label>
+      <details class="settings">
+        <summary>Transfer settings</summary>
+        <div class="row">
+          <label>
+            tx fps
+            <select id="cfg-fps">
+              <option>10</option><option>15</option><option>20</option>
+              <option selected>24</option><option>30</option><option>60</option>
+            </select>
+          </label>
+          <label>
+            bytes / frame
+            <select id="cfg-bytes">
+              <option>500</option><option>1000</option><option selected>1465</option>
+              <option>1850</option><option>2331</option><option>2953</option>
+            </select>
+          </label>
+          <label>
+            error correction
+            <select id="cfg-ecc">
+              <option selected>L</option><option>M</option><option>Q</option><option>H</option>
+            </select>
+          </label>
+          <label>
+            display size
+            <input id="cfg-size" type="range" min="300" max="1200" step="50" value="900" />
+          </label>
+        </div>
+      </details>
+      <div class="stage" id="stage" hidden><canvas id="qr" width="16" height="16"></canvas></div>
+      <div class="hint footer-hint">
+        Open <a href="../receive/">Receive file</a> on the other device. Turn up this screen's brightness.
       </div>
-      <div class="hint" style="text-align: left; padding-top: 8px">
-        Changes restart the stream — the receiver resets automatically (new
-        session id in the frame headers; that's the fountain protocol's gift).
-      </div>
-    </details>
-    <div class="stage" id="stage" hidden><canvas id="qr" width="16" height="16"></canvas></div>
-    <div class="hint">
-      Open <a href="../receive/">Receive</a> on the other device. Max screen
-      brightness helps; stop when the receiver says done.
-    </div>
+    </main>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/send/index.html
+++ b/send/index.html
@@ -8,17 +8,14 @@
   </head>
   <body>
     <h1>DECIMEN <small>— Fountain QR File Transfer</small></h1>
-    <div class="hint" id="specs">loading payload…</div>
+    <div class="hint" id="specs">choose a file to begin</div>
+    <label class="file-picker">
+      <span>Choose any file · up to 64 MB</span>
+      <input id="cfg-file" type="file" />
+    </label>
     <details class="settings">
       <summary>Settings</summary>
       <div class="row">
-        <label>
-          payload
-          <select id="cfg-payload">
-            <option value="../success.png" selected>512 KB image</option>
-            <option value="../success-2mb.png">2 MB image</option>
-          </select>
-        </label>
         <label>
           tx fps
           <select id="cfg-fps">
@@ -60,10 +57,10 @@
         session id in the frame headers; that's the fountain protocol's gift).
       </div>
     </details>
-    <div class="stage"><canvas id="qr" width="16" height="16"></canvas></div>
+    <div class="stage" id="stage" hidden><canvas id="qr" width="16" height="16"></canvas></div>
     <div class="hint">
-      Max screen brightness helps. The stream loops forever — stop when the
-      receiver says done.
+      Open <a href="../receive/">Receive</a> on the other device. Max screen
+      brightness helps; stop when the receiver says done.
     </div>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/send/main.ts
+++ b/send/main.ts
@@ -14,37 +14,76 @@
 
 import QRCode from "qrcode";
 import { LTEncoder } from "../shared/fountain";
-import { HEADER_LEN, fnv1a, packFrame, type FrameHeader } from "../shared/protocol";
+import {
+  HEADER_LEN,
+  MAX_FILE_BYTES,
+  fnv1a,
+  packFile,
+  packFrame,
+  type FrameHeader,
+} from "../shared/protocol";
 
 const MARGIN = 4; // quiet-zone modules
 const LOOKAHEAD = 3;
 
 const canvas = document.getElementById("qr") as HTMLCanvasElement;
+const stage = document.getElementById("stage") as HTMLDivElement;
 const specs = document.getElementById("specs")!;
-const cfgPayload = document.getElementById("cfg-payload") as HTMLSelectElement;
+const cfgFile = document.getElementById("cfg-file") as HTMLInputElement;
 const cfgFps = document.getElementById("cfg-fps") as HTMLSelectElement;
 const cfgBytes = document.getElementById("cfg-bytes") as HTMLSelectElement;
 const cfgEcc = document.getElementById("cfg-ecc") as HTMLSelectElement;
 const cfgSize = document.getElementById("cfg-size") as HTMLInputElement;
 
-const payloadCache = new Map<string, Uint8Array>();
+let selectedFile: {
+  name: string;
+  size: number;
+  payload: Uint8Array;
+  compression: "none" | "gzip";
+  transmittedSize: number;
+} | null = null;
 let generation = 0; // bumped on every restart; stale loops see it and die
 
-async function loadPayload(url: string): Promise<Uint8Array | null> {
-  const hit = payloadCache.get(url);
-  if (hit) return hit;
-  const res = await fetch(url);
-  if (!res.ok) return null;
-  const bytes = new Uint8Array(await res.arrayBuffer());
-  payloadCache.set(url, bytes);
-  return bytes;
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+async function selectFile(): Promise<void> {
+  const file = cfgFile.files?.[0];
+  if (!file) return;
+  const selectionGeneration = ++generation;
+  selectedFile = null;
+  stage.hidden = true;
+  if (file.size === 0 || file.size > MAX_FILE_BYTES) {
+    specs.textContent = file.size === 0 ? "✗ choose a non-empty file" : "✗ files are limited to 64 MB";
+    return;
+  }
+
+  specs.textContent = `preparing ${file.name}…`;
+  try {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const packed = await packFile(file.name, file.type, bytes);
+    if (selectionGeneration !== generation) return;
+    selectedFile = {
+      name: file.name,
+      size: file.size,
+      payload: packed.container,
+      compression: packed.compression,
+      transmittedSize: packed.transmittedSize,
+    };
+    await startStream();
+  } catch (error) {
+    specs.textContent = `✗ ${error instanceof Error ? error.message : String(error)}`;
+  }
 }
 
 async function main() {
-  for (const el of [cfgPayload, cfgFps, cfgBytes, cfgEcc, cfgSize]) {
+  cfgFile.addEventListener("change", () => void selectFile());
+  for (const el of [cfgFps, cfgBytes, cfgEcc, cfgSize]) {
     el.addEventListener("change", () => void startStream());
   }
-  await startStream();
   try {
     await (navigator as Navigator & { wakeLock?: { request(t: "screen"): Promise<unknown> } })
       .wakeLock?.request("screen");
@@ -55,11 +94,11 @@ async function main() {
 
 async function startStream() {
   const gen = ++generation;
-  const payload = await loadPayload(cfgPayload.value);
-  if (!payload) {
-    specs.textContent = `✗ couldn't load ${cfgPayload.value}`;
+  if (!selectedFile) {
+    specs.textContent = "choose a file to begin";
     return;
   }
+  const { name, size: fileSize, payload, compression, transmittedSize } = selectedFile;
   if (gen !== generation) return; // superseded while fetching
   const txFps = Number(cfgFps.value);
   const frameBytes = Number(cfgBytes.value);
@@ -68,6 +107,11 @@ async function startStream() {
 
   const sessionId = (Math.floor(Math.random() * 0xffff) + 1) & 0xffff;
   const blockLen = frameBytes - HEADER_LEN;
+  if (Math.ceil(payload.length / blockLen) > 0xffff) {
+    stage.hidden = true;
+    specs.textContent = "✗ this file needs a larger bytes-per-frame setting";
+    return;
+  }
   const encoder = new LTEncoder(payload, blockLen, sessionId);
   const header: FrameHeader = {
     sessionId,
@@ -84,6 +128,7 @@ async function startStream() {
   const staging = document.createElement("canvas");
   const queue: ImageData[] = [];
   let nextSeq = 0;
+  stage.hidden = false;
 
   const sizeCanvas = () => {
     const dpr = window.devicePixelRatio || 1;
@@ -112,7 +157,9 @@ async function startStream() {
       sizeCanvas();
       specs.textContent =
         `${txFps} FPS · ${frameBytes} bytes per frame · V${version} · ECC ${ecc} · ` +
-        `${Math.round(payload.length / 1024)} KB payload · K=${encoder.k}`;
+        `${name} · ${formatBytes(fileSize)} · ` +
+        `${compression === "gzip" ? `gzip ${formatBytes(transmittedSize)}` : "no compression"} · ` +
+        `K=${encoder.k}`;
     }
     const size = qr.modules.size;
     const data = qr.modules.data;

--- a/send/main.ts
+++ b/send/main.ts
@@ -13,6 +13,7 @@
 //   handles erasures, and a frame is either decoded whole or discarded.
 
 import QRCode from "qrcode";
+import { fitQrDisplaySize } from "../shared/display";
 import { LTEncoder } from "../shared/fountain";
 import { packPrivateNote } from "../shared/notes";
 import {
@@ -47,6 +48,7 @@ let selectedFile: {
   transmittedSize: number;
 } | null = null;
 let generation = 0; // bumped on every restart; stale loops see it and die
+let resizeDisplay: (() => void) | null = null;
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -108,6 +110,7 @@ async function selectNote(): Promise<void> {
 async function main() {
   cfgFile?.addEventListener("change", () => void selectFile());
   sendNoteBtn?.addEventListener("click", () => void selectNote());
+  window.addEventListener("resize", () => resizeDisplay?.());
   for (const el of [cfgFps, cfgBytes, cfgEcc, cfgSize]) {
     el.addEventListener("change", () => void startStream());
   }
@@ -121,6 +124,7 @@ async function main() {
 
 async function startStream() {
   const gen = ++generation;
+  resizeDisplay = null;
   if (!selectedFile) {
     specs.textContent = transferMode === "note" ? "write a note to begin" : "choose a file to begin";
     return;
@@ -160,7 +164,20 @@ async function startStream() {
   const sizeCanvas = () => {
     const dpr = window.devicePixelRatio || 1;
     const total = modules + 2 * MARGIN;
-    const cssBudget = Math.min(0.9 * Math.min(window.innerWidth, window.innerHeight), displayPx);
+    const containerWidth = stage.parentElement?.getBoundingClientRect().width ?? window.innerWidth;
+    const stageStyle = getComputedStyle(stage);
+    const horizontalChrome =
+      Number.parseFloat(stageStyle.paddingLeft) +
+      Number.parseFloat(stageStyle.paddingRight) +
+      Number.parseFloat(stageStyle.borderLeftWidth) +
+      Number.parseFloat(stageStyle.borderRightWidth);
+    const cssBudget = fitQrDisplaySize(
+      window.innerWidth,
+      window.innerHeight,
+      containerWidth,
+      displayPx,
+      horizontalChrome,
+    );
     scale = Math.max(1, Math.floor((cssBudget * dpr) / total));
     staging.width = total;
     staging.height = total;
@@ -182,6 +199,7 @@ async function startStream() {
       version = qr.version;
       modules = qr.modules.size;
       sizeCanvas();
+      resizeDisplay = sizeCanvas;
       specs.textContent =
         `${txFps} FPS · ${frameBytes} bytes per frame · V${version} · ECC ${ecc} · ` +
         `${name} · ${formatBytes(fileSize)} · ` +

--- a/send/main.ts
+++ b/send/main.ts
@@ -14,6 +14,7 @@
 
 import QRCode from "qrcode";
 import { LTEncoder } from "../shared/fountain";
+import { packPrivateNote } from "../shared/notes";
 import {
   HEADER_LEN,
   MAX_FILE_BYTES,
@@ -29,7 +30,10 @@ const LOOKAHEAD = 3;
 const canvas = document.getElementById("qr") as HTMLCanvasElement;
 const stage = document.getElementById("stage") as HTMLDivElement;
 const specs = document.getElementById("specs")!;
-const cfgFile = document.getElementById("cfg-file") as HTMLInputElement;
+const transferMode = document.body.dataset.transferMode === "note" ? "note" : "file";
+const cfgFile = document.getElementById("cfg-file") as HTMLInputElement | null;
+const noteText = document.getElementById("note-text") as HTMLTextAreaElement | null;
+const sendNoteBtn = document.getElementById("send-note") as HTMLButtonElement | null;
 const cfgFps = document.getElementById("cfg-fps") as HTMLSelectElement;
 const cfgBytes = document.getElementById("cfg-bytes") as HTMLSelectElement;
 const cfgEcc = document.getElementById("cfg-ecc") as HTMLSelectElement;
@@ -51,7 +55,7 @@ function formatBytes(bytes: number): string {
 }
 
 async function selectFile(): Promise<void> {
-  const file = cfgFile.files?.[0];
+  const file = cfgFile?.files?.[0];
   if (!file) return;
   const selectionGeneration = ++generation;
   selectedFile = null;
@@ -79,8 +83,31 @@ async function selectFile(): Promise<void> {
   }
 }
 
+async function selectNote(): Promise<void> {
+  if (!noteText) return;
+  const selectionGeneration = ++generation;
+  selectedFile = null;
+  stage.hidden = true;
+  specs.textContent = "preparing private note…";
+  try {
+    const { note, packed } = await packPrivateNote(noteText.value);
+    if (selectionGeneration !== generation) return;
+    selectedFile = {
+      name: "Private note",
+      size: new TextEncoder().encode(note.text).length,
+      payload: packed.container,
+      compression: packed.compression,
+      transmittedSize: packed.transmittedSize,
+    };
+    await startStream();
+  } catch (error) {
+    specs.textContent = `✗ ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
 async function main() {
-  cfgFile.addEventListener("change", () => void selectFile());
+  cfgFile?.addEventListener("change", () => void selectFile());
+  sendNoteBtn?.addEventListener("click", () => void selectNote());
   for (const el of [cfgFps, cfgBytes, cfgEcc, cfgSize]) {
     el.addEventListener("change", () => void startStream());
   }
@@ -95,7 +122,7 @@ async function main() {
 async function startStream() {
   const gen = ++generation;
   if (!selectedFile) {
-    specs.textContent = "choose a file to begin";
+    specs.textContent = transferMode === "note" ? "write a note to begin" : "choose a file to begin";
     return;
   }
   const { name, size: fileSize, payload, compression, transmittedSize } = selectedFile;

--- a/shared/display.ts
+++ b/shared/display.ts
@@ -1,0 +1,11 @@
+export function fitQrDisplaySize(
+  viewportWidth: number,
+  viewportHeight: number,
+  containerWidth: number,
+  requestedSize: number,
+  horizontalChrome = 0,
+): number {
+  const viewportBudget = 0.9 * Math.min(viewportWidth, viewportHeight);
+  const containerBudget = Math.max(1, containerWidth - horizontalChrome);
+  return Math.max(1, Math.min(viewportBudget, containerBudget, requestedSize));
+}

--- a/shared/notes.ts
+++ b/shared/notes.ts
@@ -1,0 +1,124 @@
+import {
+  packFile,
+  unpackFile,
+  verifyFile,
+  type OpticalFile,
+  type PackedOpticalFile,
+} from "./protocol";
+
+export const NOTE_MEDIA_TYPE = "application/vnd.decimen.note+json";
+export const MAX_NOTE_BYTES = 256 * 1024;
+export const NOTE_STORAGE_KEY = "decimen.private-notes.v1";
+export const MAX_STORED_NOTES = 100;
+
+export interface PrivateNote {
+  version: 1;
+  id: string;
+  text: string;
+  createdAt: number;
+}
+
+export interface StoredNote extends PrivateNote {
+  receivedAt: number;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+function isPrivateNote(value: unknown): value is PrivateNote {
+  if (!value || typeof value !== "object") return false;
+  const note = value as Partial<PrivateNote>;
+  return (
+    note.version === 1 &&
+    typeof note.id === "string" &&
+    note.id.length > 0 &&
+    note.id.length <= 128 &&
+    typeof note.text === "string" &&
+    Number.isFinite(note.createdAt) &&
+    (note.createdAt ?? 0) > 0 &&
+    encoder.encode(note.text).length <= MAX_NOTE_BYTES
+  );
+}
+
+function isStoredNote(value: unknown): value is StoredNote {
+  return (
+    isPrivateNote(value) &&
+    Number.isFinite((value as Partial<StoredNote>).receivedAt) &&
+    ((value as Partial<StoredNote>).receivedAt ?? 0) > 0
+  );
+}
+
+export async function packPrivateNote(
+  text: string,
+  createdAt = Date.now(),
+  id = crypto.randomUUID(),
+): Promise<{ note: PrivateNote; packed: PackedOpticalFile }> {
+  if (text.trim().length === 0) throw new Error("Write a note before sending it.");
+  if (encoder.encode(text).length > MAX_NOTE_BYTES) {
+    throw new Error("Private notes are limited to 256 KB.");
+  }
+  const note: PrivateNote = { version: 1, id, text, createdAt };
+  const bytes = encoder.encode(JSON.stringify(note));
+  const packed = await packFile("private-note.decimen-note", NOTE_MEDIA_TYPE, bytes);
+  return { note, packed };
+}
+
+export async function unpackPrivateNote(
+  container: Uint8Array,
+): Promise<{ note: PrivateNote; file: OpticalFile }> {
+  const file = await unpackFile(container);
+  if (file.type !== NOTE_MEDIA_TYPE) {
+    throw new Error("This is a file stream. Open Receive file instead.");
+  }
+  if (!(await verifyFile(file))) {
+    throw new Error("The recovered note failed SHA-256 verification.");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(decoder.decode(file.bytes));
+  } catch {
+    throw new Error("The recovered note is not valid UTF-8 JSON.");
+  }
+  if (!isPrivateNote(value)) throw new Error("The recovered note is invalid.");
+  return { note: value, file };
+}
+
+export function loadStoredNotes(storage: StorageLike): StoredNote[] {
+  try {
+    const raw = storage.getItem(NOTE_STORAGE_KEY);
+    if (!raw) return [];
+    const value: unknown = JSON.parse(raw);
+    if (!Array.isArray(value)) return [];
+    return value.filter(isStoredNote).slice(0, MAX_STORED_NOTES);
+  } catch {
+    return [];
+  }
+}
+
+export function storeReceivedNote(
+  storage: StorageLike,
+  note: PrivateNote,
+  receivedAt = Date.now(),
+): { notes: StoredNote[]; added: boolean } {
+  const current = loadStoredNotes(storage);
+  if (current.some((item) => item.id === note.id)) return { notes: current, added: false };
+  const notes = [{ ...note, receivedAt }, ...current].slice(0, MAX_STORED_NOTES);
+  storage.setItem(NOTE_STORAGE_KEY, JSON.stringify(notes));
+  return { notes, added: true };
+}
+
+export function deleteStoredNote(storage: StorageLike, id: string): StoredNote[] {
+  const notes = loadStoredNotes(storage).filter((note) => note.id !== id);
+  storage.setItem(NOTE_STORAGE_KEY, JSON.stringify(notes));
+  return notes;
+}
+
+export function clearStoredNotes(storage: StorageLike): void {
+  storage.removeItem(NOTE_STORAGE_KEY);
+}

--- a/shared/progress.ts
+++ b/shared/progress.ts
@@ -1,0 +1,38 @@
+export const EXPECTED_FOUNTAIN_OVERHEAD = 1.18;
+
+export interface TransferProgressEstimate {
+  fraction: number;
+  targetFrames: number;
+  etaSeconds?: number;
+  finishing: boolean;
+}
+
+export function estimateTransferProgress(
+  sourceBlocks: number,
+  uniqueFrames: number,
+  elapsedSeconds: number,
+): TransferProgressEstimate {
+  const targetFrames = Math.max(
+    sourceBlocks,
+    Math.ceil(sourceBlocks * EXPECTED_FOUNTAIN_OVERHEAD),
+  );
+  const finishing = uniqueFrames >= targetFrames;
+  const fraction = finishing ? 0.99 : Math.min(0.99, uniqueFrames / targetFrames);
+  const rate = elapsedSeconds > 0 ? uniqueFrames / elapsedSeconds : 0;
+  const etaSeconds =
+    uniqueFrames >= 3 && elapsedSeconds >= 1 && rate > 0 && !finishing
+      ? (targetFrames - uniqueFrames) / rate
+      : undefined;
+  return { fraction, targetFrames, etaSeconds, finishing };
+}
+
+export function formatDuration(seconds: number): string {
+  const rounded = Math.max(1, Math.ceil(seconds));
+  if (rounded < 60) return `${rounded}s`;
+  const minutes = Math.floor(rounded / 60);
+  const remainder = rounded % 60;
+  if (minutes < 60) return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+}

--- a/shared/progress.ts
+++ b/shared/progress.ts
@@ -2,7 +2,7 @@ export const EXPECTED_FOUNTAIN_OVERHEAD = 1.18;
 
 export interface TransferProgressEstimate {
   fraction: number;
-  targetFrames: number;
+  minimumFrames: number;
   etaSeconds?: number;
   finishing: boolean;
 }
@@ -12,18 +12,18 @@ export function estimateTransferProgress(
   uniqueFrames: number,
   elapsedSeconds: number,
 ): TransferProgressEstimate {
-  const targetFrames = Math.max(
-    sourceBlocks,
-    Math.ceil(sourceBlocks * EXPECTED_FOUNTAIN_OVERHEAD),
-  );
-  const finishing = uniqueFrames >= targetFrames;
-  const fraction = finishing ? 0.99 : Math.min(0.99, uniqueFrames / targetFrames);
+  // K source blocks is the only hard milestone: recovery cannot complete
+  // before K independent frames, but fountain overhead varies per stream.
+  // Fill toward K, then hold at 99% until the decoder actually completes.
+  const minimumFrames = Math.max(1, sourceBlocks);
+  const finishing = uniqueFrames >= minimumFrames;
+  const fraction = finishing ? 0.99 : Math.min(0.99, uniqueFrames / minimumFrames);
   const rate = elapsedSeconds > 0 ? uniqueFrames / elapsedSeconds : 0;
   const etaSeconds =
     uniqueFrames >= 3 && elapsedSeconds >= 1 && rate > 0 && !finishing
-      ? (targetFrames - uniqueFrames) / rate
+      ? (minimumFrames - uniqueFrames) / rate
       : undefined;
-  return { fraction, targetFrames, etaSeconds, finishing };
+  return { fraction, minimumFrames, etaSeconds, finishing };
 }
 
 export function formatDuration(seconds: number): string {

--- a/shared/progress.ts
+++ b/shared/progress.ts
@@ -2,28 +2,47 @@ export const EXPECTED_FOUNTAIN_OVERHEAD = 1.18;
 
 export interface TransferProgressEstimate {
   fraction: number;
-  minimumFrames: number;
+  expectedFrames: number;
   etaSeconds?: number;
-  finishing: boolean;
+  phase: "collecting" | "decoding";
 }
 
 export function estimateTransferProgress(
   sourceBlocks: number,
   uniqueFrames: number,
   elapsedSeconds: number,
+  solvedBlocks = 0,
 ): TransferProgressEstimate {
-  // K source blocks is the only hard milestone: recovery cannot complete
-  // before K independent frames, but fountain overhead varies per stream.
-  // Fill toward K, then hold at 99% until the decoder actually completes.
   const minimumFrames = Math.max(1, sourceBlocks);
-  const finishing = uniqueFrames >= minimumFrames;
-  const fraction = finishing ? 0.99 : Math.min(0.99, uniqueFrames / minimumFrames);
+  const expectedFrames = Math.max(
+    minimumFrames + 1,
+    Math.ceil(minimumFrames * EXPECTED_FOUNTAIN_OVERHEAD),
+  );
+  const expectedRedundancy = expectedFrames - minimumFrames;
+
+  // Frames drive a continuously moving baseline: 0–86% while collecting the
+  // theoretical minimum, 86–96% through the expected redundancy, then an
+  // asymptotic 96–99% if this particular stream needs more. Actual decoded
+  // blocks can move the bar further ahead at any time.
+  let frameFraction: number;
+  if (uniqueFrames < minimumFrames) {
+    frameFraction = 0.86 * (uniqueFrames / minimumFrames);
+  } else if (uniqueFrames <= expectedFrames) {
+    frameFraction =
+      0.86 + 0.1 * ((uniqueFrames - minimumFrames) / expectedRedundancy);
+  } else {
+    const extra = (uniqueFrames - expectedFrames) / expectedRedundancy;
+    frameFraction = 0.96 + 0.03 * (1 - Math.exp(-extra));
+  }
+  const decodedFraction = 0.99 * Math.min(1, solvedBlocks / minimumFrames);
+  const fraction = Math.min(0.99, Math.max(frameFraction, decodedFraction));
+  const phase = uniqueFrames < minimumFrames ? "collecting" : "decoding";
   const rate = elapsedSeconds > 0 ? uniqueFrames / elapsedSeconds : 0;
   const etaSeconds =
-    uniqueFrames >= 3 && elapsedSeconds >= 1 && rate > 0 && !finishing
-      ? (minimumFrames - uniqueFrames) / rate
+    uniqueFrames >= 3 && elapsedSeconds >= 1 && rate > 0 && uniqueFrames < expectedFrames
+      ? (expectedFrames - uniqueFrames) / rate
       : undefined;
-  return { fraction, minimumFrames, etaSeconds, finishing };
+  return { fraction, expectedFrames, etaSeconds, phase };
 }
 
 export function formatDuration(seconds: number): string {

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -1,3 +1,5 @@
+import { gzip, gunzip } from "fflate";
+
 // Frame protocol: every QR frame is fully self-describing, so there is NO
 // handshake — the receiver locks onto a stream mid-flight, and a new session
 // id on any frame simply starts a fresh transfer.
@@ -9,12 +11,163 @@
 //   4  u32  seq         drives the fountain PRNG (see fountain.ts)
 //   8  u16  k           source block count
 //  10  u16  blockLen    payload bytes per frame
-//  12  u32  totalLen    file length in bytes
-//  16  u32  payloadFnv  FNV-1a of the whole file — verified on completion
+//  12  u32  totalLen    protected file-container length in bytes
+//  16  u32  payloadFnv  FNV-1a of the whole container — verified on completion
 
 export const HEADER_LEN = 20;
+export const MAX_FILE_BYTES = 64 * 1024 * 1024;
+const FILE_HEADER_LEN = 49;
 const MAGIC0 = 0xd1;
 const MAGIC1 = 0x0c;
+const FILE_MAGIC = new Uint8Array([0x44, 0x43, 0x46, 0x32]); // DCF2
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export type CompressionMode = "none" | "gzip";
+
+export interface PackedOpticalFile {
+  container: Uint8Array;
+  compression: CompressionMode;
+  originalSize: number;
+  transmittedSize: number;
+}
+
+export interface OpticalFile {
+  name: string;
+  type: string;
+  bytes: Uint8Array;
+  sha256: Uint8Array;
+  compression: CompressionMode;
+  transmittedSize: number;
+}
+
+async function digest(bytes: Uint8Array): Promise<Uint8Array> {
+  const stableBytes = Uint8Array.from(bytes);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", stableBytes));
+}
+
+function gzipAsync(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    gzip(bytes, { level: 9, mem: 12, mtime: 0 }, (error, compressed) => {
+      if (error) reject(error);
+      else resolve(compressed);
+    });
+  });
+}
+
+function gunzipAsync(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    gunzip(bytes, (error, decompressed) => {
+      if (error) reject(error);
+      else resolve(decompressed);
+    });
+  });
+}
+
+export async function packFile(
+  name: string,
+  type: string,
+  bytes: Uint8Array,
+): Promise<PackedOpticalFile> {
+  if (bytes.length === 0) throw new Error("Choose a non-empty file.");
+  if (bytes.length > MAX_FILE_BYTES) {
+    throw new Error("Files are limited to 64 MB in this browser build.");
+  }
+
+  const safeName = name.split(/[\\/]/).pop() || "transfer.bin";
+  const nameBytes = textEncoder.encode(safeName);
+  const typeBytes = textEncoder.encode(type || "application/octet-stream");
+  if (nameBytes.length > 0xffff || typeBytes.length > 0xffff) {
+    throw new Error("The file name or media type is too long.");
+  }
+
+  const [sha256, compressed] = await Promise.all([
+    digest(bytes),
+    bytes.length >= 768 ? gzipAsync(bytes) : Promise.resolve(undefined),
+  ]);
+  const useGzip = compressed !== undefined && compressed.length + 64 < bytes.length;
+  const transmitted = useGzip ? compressed : bytes;
+  const compression: CompressionMode = useGzip ? "gzip" : "none";
+  const out = new Uint8Array(
+    FILE_HEADER_LEN + nameBytes.length + typeBytes.length + transmitted.length,
+  );
+  const view = new DataView(out.buffer);
+  out.set(FILE_MAGIC, 0);
+  view.setUint8(4, useGzip ? 1 : 0);
+  view.setUint16(5, nameBytes.length, true);
+  view.setUint16(7, typeBytes.length, true);
+  view.setUint32(9, bytes.length, true);
+  view.setUint32(13, transmitted.length, true);
+  out.set(sha256, 17);
+  out.set(nameBytes, FILE_HEADER_LEN);
+  out.set(typeBytes, FILE_HEADER_LEN + nameBytes.length);
+  out.set(transmitted, FILE_HEADER_LEN + nameBytes.length + typeBytes.length);
+  return {
+    container: out,
+    compression,
+    originalSize: bytes.length,
+    transmittedSize: transmitted.length,
+  };
+}
+
+export async function unpackFile(container: Uint8Array): Promise<OpticalFile> {
+  if (container.length < FILE_HEADER_LEN) throw new Error("The recovered file header is incomplete.");
+  for (let i = 0; i < FILE_MAGIC.length; i++) {
+    if (container[i] !== FILE_MAGIC[i]) throw new Error("The recovered file header is invalid.");
+  }
+
+  const view = new DataView(container.buffer, container.byteOffset, container.byteLength);
+  const compressionByte = view.getUint8(4);
+  if (compressionByte > 1) throw new Error("The recovered file uses unsupported compression.");
+  const compression: CompressionMode = compressionByte === 1 ? "gzip" : "none";
+  const nameLength = view.getUint16(5, true);
+  const typeLength = view.getUint16(7, true);
+  const fileLength = view.getUint32(9, true);
+  const transmittedLength = view.getUint32(13, true);
+  const dataOffset = FILE_HEADER_LEN + nameLength + typeLength;
+  if (
+    fileLength === 0 ||
+    fileLength > MAX_FILE_BYTES ||
+    transmittedLength === 0 ||
+    transmittedLength > MAX_FILE_BYTES ||
+    dataOffset + transmittedLength !== container.length
+  ) {
+    throw new Error("The recovered file length does not match its header.");
+  }
+
+  const transmitted = container.slice(dataOffset);
+  if (compression === "gzip") {
+    if (transmitted.length < 18) throw new Error("The recovered gzip payload is incomplete.");
+    const trailer = new DataView(
+      transmitted.buffer,
+      transmitted.byteOffset + transmitted.byteLength - 4,
+      4,
+    );
+    if (trailer.getUint32(0, true) !== fileLength) {
+      throw new Error("The gzip payload length does not match its file header.");
+    }
+  }
+  const bytes = compression === "gzip" ? await gunzipAsync(transmitted) : transmitted;
+  if (bytes.length !== fileLength) {
+    throw new Error("The decompressed file length does not match its header.");
+  }
+
+  return {
+    name: textDecoder.decode(container.subarray(FILE_HEADER_LEN, FILE_HEADER_LEN + nameLength)) || "transfer.bin",
+    type:
+      textDecoder.decode(container.subarray(FILE_HEADER_LEN + nameLength, dataOffset)) ||
+      "application/octet-stream",
+    sha256: container.slice(17, 49),
+    bytes,
+    compression,
+    transmittedSize: transmittedLength,
+  };
+}
+
+export async function verifyFile(file: OpticalFile): Promise<boolean> {
+  const actual = await digest(file.bytes);
+  return actual.every((value, index) => value === file.sha256[index]);
+}
 
 export interface FrameHeader {
   sessionId: number;

--- a/shared/style.css
+++ b/shared/style.css
@@ -220,3 +220,612 @@ details.settings input[type="range"] {
 .metric .v.ok {
   color: #7dc98f;
 }
+
+/* Product shell */
+:root {
+  color-scheme: dark;
+  --bg: #121009;
+  --panel: #1b1712;
+  --panel-strong: #211b13;
+  --line: #332918;
+  --line-bright: #5b4325;
+  --text: #ede5d4;
+  --muted: #9a8f76;
+  --amber: #ffb257;
+  --green: #7dc98f;
+  --red: #d86455;
+}
+
+.home-page,
+.tool-page,
+.receiver-page {
+  display: block;
+  padding: 0;
+  min-height: 100svh;
+  background:
+    radial-gradient(circle at 80% -10%, rgba(255, 178, 87, 0.09), transparent 35%),
+    var(--bg);
+}
+
+.site-header {
+  width: 100%;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: max(14px, env(safe-area-inset-top)) max(22px, env(safe-area-inset-right)) 14px max(22px, env(safe-area-inset-left));
+  border-bottom: 1px solid var(--line);
+  background: rgba(18, 16, 9, 0.9);
+  backdrop-filter: blur(14px);
+  position: relative;
+  z-index: 3;
+}
+
+.brand {
+  color: var(--amber);
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-decoration: none;
+}
+
+.header-note,
+.mode-badge {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mode-badge {
+  color: var(--text);
+  border: 1px solid var(--line-bright);
+  border-radius: 999px;
+  padding: 4px 9px;
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 8px;
+  color: var(--amber);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+/* Homepage */
+.home-shell {
+  width: min(1120px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: clamp(56px, 9vw, 110px) 0 48px;
+}
+
+.hero {
+  max-width: 820px;
+  margin-bottom: clamp(48px, 7vw, 82px);
+}
+
+.hero h1 {
+  margin: 0;
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: clamp(44px, 8vw, 94px);
+  line-height: 0.96;
+  letter-spacing: -0.07em;
+  text-align: left;
+  text-transform: none;
+}
+
+.hero-copy {
+  max-width: 660px;
+  margin: 28px 0 0;
+  color: var(--muted);
+  font-size: clamp(15px, 2vw, 18px);
+  line-height: 1.65;
+}
+
+.transfer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.transfer-card {
+  min-height: 390px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 30px;
+  padding: clamp(24px, 4vw, 42px);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: linear-gradient(150deg, var(--panel-strong), var(--panel));
+}
+
+.note-feature-card {
+  background:
+    linear-gradient(150deg, rgba(255, 178, 87, 0.08), transparent 55%),
+    var(--panel);
+  border-color: var(--line-bright);
+}
+
+.card-number {
+  align-self: flex-end;
+  color: #66583f;
+  font-size: 13px;
+}
+
+.transfer-card h2 {
+  max-width: 430px;
+  margin: 0 0 14px;
+  color: var(--text);
+  font-size: clamp(25px, 3.4vw, 38px);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.transfer-card p:not(.card-kicker) {
+  max-width: 480px;
+  margin: 0;
+  color: var(--muted);
+}
+
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 22px;
+  min-width: 150px;
+  padding: 12px 15px;
+  color: var(--text);
+  border: 1px solid var(--line-bright);
+  border-radius: 8px;
+  text-decoration: none;
+}
+
+.action.primary {
+  color: var(--bg);
+  background: var(--amber);
+  border-color: var(--amber);
+  font-weight: 800;
+}
+
+.how-it-works {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 28px;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.how-it-works i {
+  height: 1px;
+  flex: 1;
+  background: var(--line);
+}
+
+.privacy-note {
+  margin: 30px 0 0;
+  color: #756b57;
+  font-size: 11px;
+  text-align: center;
+}
+
+/* Senders */
+.send-shell {
+  width: min(720px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: clamp(32px, 6vw, 64px) 0 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.tool-intro {
+  width: 100%;
+  margin-bottom: 14px;
+}
+
+.tool-intro h1,
+.receiver-heading h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(30px, 6vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.05em;
+  text-align: left;
+  text-transform: none;
+}
+
+.tool-intro > p:last-child {
+  max-width: 600px;
+  margin: 14px 0 0;
+  color: var(--muted);
+}
+
+.status-line {
+  min-height: 20px;
+  max-width: none;
+  text-align: left;
+}
+
+.send-shell .status-line,
+.send-shell .file-picker,
+.send-shell details.settings,
+.note-composer {
+  width: 100%;
+}
+
+.send-shell .stage {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.note-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--amber);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.note-composer textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 168px;
+  padding: 16px;
+  color: var(--text);
+  background: var(--panel);
+  border: 1px solid var(--line-bright);
+  border-radius: 10px;
+  outline: none;
+  font: 16px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  text-transform: none;
+}
+
+.note-composer textarea:focus {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 3px rgba(255, 178, 87, 0.1);
+}
+
+.footer-hint {
+  margin-top: 6px;
+}
+
+/* Compact receiver: progress stays on the camera viewport. */
+.receiver-page .site-header {
+  position: sticky;
+  top: 0;
+}
+
+.receiver-shell {
+  width: min(680px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: 18px 0 max(28px, env(safe-area-inset-bottom));
+}
+
+.receiver-primary {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.receiver-heading {
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 2px;
+}
+
+.receiver-heading h1 {
+  font-size: clamp(25px, 5vw, 36px);
+}
+
+.receiver-heading .eyebrow {
+  margin-bottom: 4px;
+}
+
+.receiver-heading .status-line {
+  max-width: 48%;
+  text-align: right;
+  line-height: 1.3;
+}
+
+.receiver-primary > details.settings,
+.receiver-primary > button,
+.receiver-primary > #result {
+  width: 100%;
+}
+
+.receiver-primary > button {
+  min-height: 52px;
+}
+
+.preview {
+  position: relative;
+  width: min(100%, 640px);
+  aspect-ratio: 4 / 3;
+  max-height: calc(100dvh - 156px);
+  background: #050403;
+  border: 1px solid var(--line-bright);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.preview video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+.transfer-hud {
+  position: absolute;
+  inset: auto 0 0;
+  z-index: 2;
+  padding: 54px 14px 14px;
+  background: linear-gradient(transparent, rgba(5, 4, 3, 0.94) 55%);
+  pointer-events: none;
+}
+
+.transfer-hud .progress-status,
+.transfer-hud .progress {
+  width: 100%;
+}
+
+.transfer-hud .progress-status {
+  margin-bottom: 7px;
+  color: #d1c6b0;
+  text-shadow: 0 1px 3px #000;
+}
+
+.transfer-hud .progress {
+  height: 12px;
+  background: rgba(18, 16, 9, 0.86);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.diagnostics {
+  margin-top: 2px;
+}
+
+.diagnostics .metrics {
+  width: 100%;
+  padding-top: 10px;
+}
+
+#result:empty {
+  display: none;
+}
+
+#result {
+  width: 100%;
+}
+
+.received-note {
+  width: 100%;
+  max-width: 640px;
+  margin: 0;
+  padding: 16px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+
+.secondary-button {
+  width: auto;
+  padding: 10px 16px;
+  color: var(--text);
+  background: transparent;
+  border: 1px solid var(--line-bright);
+  font-size: 14px;
+}
+
+/* Local note storage */
+.notes-receiver-shell {
+  width: min(1100px, calc(100% - 28px));
+  display: grid;
+  grid-template-columns: minmax(0, 640px) minmax(300px, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.notes-panel {
+  min-width: 0;
+  padding: 18px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+}
+
+.notes-panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.notes-panel h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 22px;
+  letter-spacing: -0.03em;
+}
+
+.notes-empty {
+  margin: 24px 0;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.notes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 14px;
+}
+
+.note-card {
+  padding: 14px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+
+.note-card > p {
+  margin: 10px 0 14px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: 14px;
+}
+
+.note-meta {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.note-actions {
+  display: flex;
+  gap: 14px;
+}
+
+.text-button {
+  padding: 0;
+  color: var(--amber);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.text-button.danger {
+  color: var(--red);
+}
+
+.text-button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+@media (max-width: 860px) {
+  .notes-receiver-shell {
+    display: block;
+  }
+  .notes-panel {
+    margin-top: 18px;
+  }
+}
+
+@media (max-width: 680px) {
+  .site-header {
+    min-height: 50px;
+    padding: max(11px, env(safe-area-inset-top)) 14px 11px;
+  }
+  .header-note {
+    display: none;
+  }
+  .home-shell {
+    width: min(100% - 28px, 520px);
+    padding-top: 46px;
+  }
+  .hero h1 {
+    font-size: clamp(43px, 14vw, 68px);
+  }
+  .hero-copy {
+    margin-top: 22px;
+  }
+  .transfer-grid {
+    grid-template-columns: 1fr;
+  }
+  .transfer-card {
+    min-height: 330px;
+  }
+  .how-it-works {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 9px;
+    padding-left: 12px;
+    border-left: 1px solid var(--line);
+  }
+  .how-it-works i {
+    display: none;
+  }
+  .send-shell {
+    width: calc(100% - 24px);
+    padding-top: 28px;
+  }
+  .receiver-shell,
+  .notes-receiver-shell {
+    width: calc(100% - 20px);
+    padding-top: 10px;
+  }
+  .receiver-primary {
+    gap: 8px;
+  }
+  .receiver-heading {
+    gap: 10px;
+  }
+  .receiver-heading h1 {
+    font-size: 25px;
+  }
+  .receiver-heading .status-line {
+    font-size: 10px;
+  }
+  .preview {
+    max-height: calc(100dvh - 128px);
+  }
+  .progress-status {
+    font-size: 11px;
+  }
+  .transfer-hud {
+    padding: 42px 10px 10px;
+  }
+  .notes-panel {
+    margin-top: 14px;
+  }
+}
+
+@media (max-height: 620px) and (orientation: landscape) {
+  .receiver-heading .eyebrow {
+    display: none;
+  }
+  .receiver-heading h1 {
+    font-size: 20px;
+  }
+  .preview {
+    width: auto;
+    height: calc(100dvh - 108px);
+    max-width: 100%;
+  }
+}

--- a/shared/style.css
+++ b/shared/style.css
@@ -106,6 +106,21 @@ button {
   border-radius: 7px;
   overflow: hidden;
 }
+.progress-status {
+  width: min(92vw, 480px);
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  color: #9a8f76;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+.progress-status strong {
+  color: #ffb257;
+}
+.progress-status span {
+  text-align: right;
+}
 .progress > div {
   height: 100%;
   background: #ffb257;

--- a/shared/style.css
+++ b/shared/style.css
@@ -47,6 +47,38 @@ button {
   font-weight: 700;
   cursor: pointer;
 }
+.file-picker {
+  width: min(92vw, 640px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: #ede5d4;
+  background: #1b1712;
+  border: 1px solid #4c3b22;
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.file-picker span {
+  color: #ffb257;
+  font-weight: 700;
+}
+.file-picker input {
+  max-width: 100%;
+  font: inherit;
+}
+.file-picker input::file-selector-button {
+  margin-right: 10px;
+  color: #121009;
+  background: #ffb257;
+  border: 0;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
 .stage {
   background: #fff;
   padding: 20px;
@@ -79,6 +111,9 @@ button {
   background: #ffb257;
   transition: width 0.25s;
 }
+.progress > div.error {
+  background: #d86455;
+}
 .done {
   color: #7dc98f;
   font-size: 22px;
@@ -87,6 +122,22 @@ button {
 img.received {
   max-width: min(92vw, 640px);
   border-radius: 10px;
+}
+#result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+a.download {
+  display: inline-block;
+  color: #121009;
+  background: #ffb257;
+  border-radius: 8px;
+  padding: 12px 20px;
+  font-size: 16px;
+  font-weight: 700;
+  text-decoration: none;
 }
 details.settings {
   width: min(92vw, 640px);

--- a/tests/display.test.ts
+++ b/tests/display.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fitQrDisplaySize } from "../shared/display.ts";
+
+test("QR display fits inside its container including padding", () => {
+  assert.equal(fitQrDisplaySize(1440, 1000, 720, 900, 40), 680);
+});
+
+test("QR display still respects the requested and viewport sizes", () => {
+  assert.equal(fitQrDisplaySize(1440, 1000, 1200, 600, 40), 600);
+  assert.equal(fitQrDisplaySize(390, 844, 366, 900, 40), 326);
+});

--- a/tests/notes.test.ts
+++ b/tests/notes.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  clearStoredNotes,
+  deleteStoredNote,
+  loadStoredNotes,
+  packPrivateNote,
+  storeReceivedNote,
+  unpackPrivateNote,
+  type StorageLike,
+} from "../shared/notes.ts";
+
+class MemoryStorage implements StorageLike {
+  private values = new Map<string, string>();
+  getItem(key: string) { return this.values.get(key) ?? null; }
+  setItem(key: string, value: string) { this.values.set(key, value); }
+  removeItem(key: string) { this.values.delete(key); }
+}
+
+test("private notes survive the optical container", async () => {
+  const packed = await packPrivateNote("Meet by the north door.", 1_750_000_000_000, "note-1");
+  const recovered = await unpackPrivateNote(packed.packed.container);
+
+  assert.deepEqual(recovered.note, packed.note);
+  assert.equal(recovered.file.compression, "none");
+});
+
+test("received notes are stored newest-first and deduplicated", async () => {
+  const storage = new MemoryStorage();
+  const first = (await packPrivateNote("first", 100, "first")).note;
+  const second = (await packPrivateNote("second", 200, "second")).note;
+
+  storeReceivedNote(storage, first, 300);
+  storeReceivedNote(storage, second, 400);
+  const duplicate = storeReceivedNote(storage, second, 500);
+
+  assert.equal(duplicate.added, false);
+  assert.deepEqual(loadStoredNotes(storage).map((note) => note.id), ["second", "first"]);
+  assert.deepEqual(deleteStoredNote(storage, "second").map((note) => note.id), ["first"]);
+  clearStoredNotes(storage);
+  assert.deepEqual(loadStoredNotes(storage), []);
+});
+
+test("empty private notes are rejected", async () => {
+  await assert.rejects(packPrivateNote("  \n"), /Write a note/);
+});

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { estimateTransferProgress, formatDuration } from "../shared/progress.ts";
+
+test("progress and ETA follow the observed unique-frame rate", () => {
+  const progress = estimateTransferProgress(100, 59, 10);
+  assert.equal(progress.targetFrames, 118);
+  assert.equal(progress.fraction, 0.5);
+  assert.equal(progress.etaSeconds, 10);
+  assert.equal(progress.finishing, false);
+});
+
+test("ETA waits for enough samples and caps incomplete recovery at 99%", () => {
+  assert.equal(estimateTransferProgress(100, 2, 4).etaSeconds, undefined);
+  const finishing = estimateTransferProgress(100, 118, 20);
+  assert.equal(finishing.fraction, 0.99);
+  assert.equal(finishing.finishing, true);
+});
+
+test("durations stay compact and readable", () => {
+  assert.equal(formatDuration(12.1), "13s");
+  assert.equal(formatDuration(75.1), "1m 16s");
+  assert.equal(formatDuration(3_661), "1h 1m");
+});

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -4,18 +4,23 @@ import { estimateTransferProgress, formatDuration } from "../shared/progress.ts"
 
 test("progress and ETA follow the observed unique-frame rate", () => {
   const progress = estimateTransferProgress(100, 50, 10);
-  assert.equal(progress.minimumFrames, 100);
-  assert.equal(progress.fraction, 0.5);
-  assert.equal(progress.etaSeconds, 10);
-  assert.equal(progress.finishing, false);
+  assert.equal(progress.expectedFrames, 118);
+  assert.equal(progress.fraction, 0.43);
+  assert.equal(progress.etaSeconds, 13.6);
+  assert.equal(progress.phase, "collecting");
 });
 
-test("ETA waits for enough samples and progress holds at 99% after K", () => {
+test("progress keeps moving through redundant frames", () => {
   assert.equal(estimateTransferProgress(100, 2, 4).etaSeconds, undefined);
-  const finishing = estimateTransferProgress(100, 100, 20);
-  assert.equal(finishing.fraction, 0.99);
-  assert.equal(finishing.finishing, true);
-  assert.equal(estimateTransferProgress(100, 118, 22).fraction, 0.99);
+  assert.equal(estimateTransferProgress(100, 100, 20).fraction, 0.86);
+  assert.ok(estimateTransferProgress(100, 110, 21).fraction > 0.91);
+  assert.equal(estimateTransferProgress(100, 118, 22).fraction, 0.96);
+  assert.ok(estimateTransferProgress(100, 136, 24).fraction > 0.97);
+});
+
+test("decoded blocks can advance progress and completion caps at 99%", () => {
+  assert.equal(estimateTransferProgress(100, 105, 20, 95).fraction, 0.9405);
+  assert.equal(estimateTransferProgress(100, 105, 20, 100).fraction, 0.99);
 });
 
 test("durations stay compact and readable", () => {

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -3,18 +3,19 @@ import test from "node:test";
 import { estimateTransferProgress, formatDuration } from "../shared/progress.ts";
 
 test("progress and ETA follow the observed unique-frame rate", () => {
-  const progress = estimateTransferProgress(100, 59, 10);
-  assert.equal(progress.targetFrames, 118);
+  const progress = estimateTransferProgress(100, 50, 10);
+  assert.equal(progress.minimumFrames, 100);
   assert.equal(progress.fraction, 0.5);
   assert.equal(progress.etaSeconds, 10);
   assert.equal(progress.finishing, false);
 });
 
-test("ETA waits for enough samples and caps incomplete recovery at 99%", () => {
+test("ETA waits for enough samples and progress holds at 99% after K", () => {
   assert.equal(estimateTransferProgress(100, 2, 4).etaSeconds, undefined);
-  const finishing = estimateTransferProgress(100, 118, 20);
+  const finishing = estimateTransferProgress(100, 100, 20);
   assert.equal(finishing.fraction, 0.99);
   assert.equal(finishing.finishing, true);
+  assert.equal(estimateTransferProgress(100, 118, 22).fraction, 0.99);
 });
 
 test("durations stay compact and readable", () => {

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { packFile, unpackFile, verifyFile } from "../shared/protocol.ts";
+
+test("arbitrary file metadata and bytes survive the optical container", async () => {
+  const source = new Uint8Array([0, 1, 2, 127, 128, 254, 255]);
+  const packed = await packFile("résumé.bin", "application/octet-stream", source);
+  const recovered = await unpackFile(packed.container);
+
+  assert.equal(packed.compression, "none");
+  assert.equal(recovered.name, "résumé.bin");
+  assert.equal(recovered.type, "application/octet-stream");
+  assert.deepEqual(recovered.bytes, source);
+  assert.equal(await verifyFile(recovered), true);
+});
+
+test("SHA-256 verification rejects changed file bytes", async () => {
+  const packed = await packFile("message.txt", "text/plain", new TextEncoder().encode("hello"));
+  const recovered = await unpackFile(packed.container);
+  recovered.bytes[0] ^= 0xff;
+
+  assert.equal(await verifyFile(recovered), false);
+});
+
+test("compressible files use gzip and recover exactly", async () => {
+  const source = new TextEncoder().encode("decimen optical transfer\n".repeat(4_000));
+  const packed = await packFile("notes.txt", "text/plain", source);
+  const recovered = await unpackFile(packed.container);
+
+  assert.equal(packed.compression, "gzip");
+  assert.ok(packed.transmittedSize < source.length / 10);
+  assert.equal(recovered.compression, "gzip");
+  assert.deepEqual(recovered.bytes, source);
+  assert.equal(await verifyFile(recovered), true);
+});
+
+test("gzip output length is bounded by the declared original size", async () => {
+  const source = new TextEncoder().encode("bounded output\n".repeat(1_000));
+  const packed = await packFile("bounded.txt", "text/plain", source);
+  const malformed = packed.container.slice();
+  new DataView(malformed.buffer).setUint32(9, source.length + 1, true);
+
+  await assert.rejects(unpackFile(malformed), /gzip payload length/);
+});
+
+test("malformed optical containers are rejected", async () => {
+  await assert.rejects(unpackFile(new Uint8Array(49)), /header is invalid/);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true,
     "types": ["vite/client"]
   },
-  "include": ["shared", "send", "receive"]
+  "include": ["shared", "send", "receive", "notes"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
         index: resolve(__dirname, "index.html"),
         send: resolve(__dirname, "send/index.html"),
         receive: resolve(__dirname, "receive/index.html"),
+        noteSend: resolve(__dirname, "notes/send/index.html"),
+        noteReceive: resolve(__dirname, "notes/receive/index.html"),
       },
     },
   },


### PR DESCRIPTION
## What changed

- replace the two bundled sender payload choices with an arbitrary file picker
- preserve the original filename and media type in a versioned optical file container
- cap browser-side transfers at 64 MB so the 16-bit fountain block count stays valid
- adaptively gzip files when compression saves at least 64 bytes
- verify the recovered file with SHA-256 before exposing a download
- retain image previews while supporting downloads for every file type
- document the new flow and add focused container/compression tests

## Why

The proof of concept previously streamed only the bundled 512 KB and 2 MB PNGs, and the receiver always interpreted recovered bytes as `image/png`. This makes the optical transport useful for real files while preserving the existing LT fountain and QR pipeline.

Compression remains opportunistic: small or already-compressed inputs stay raw, while text and other compressible data require fewer optical frames. The gzip trailer, declared original length, container checksum, and SHA-256 digest provide bounded decompression and layered integrity checks.

## Validation

- `npm test` — 5 passing tests covering raw and compressed round trips, metadata, SHA-256 rejection, malformed containers, and gzip size bounds
- `npm run build` — TypeScript and Vite production build pass
