### PR TITLE
fix(protocol): reject inconsistent totalLen in parseFrame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.local
 .DS_Store
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 dist/
 *.local
 .DS_Store
-node_modules/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --experimental-strip-types --test shared/protocol.test.ts"
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.5",

--- a/shared/protocol.test.ts
+++ b/shared/protocol.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  HEADER_LEN,
+  MAX_TOTAL_LEN,
+  packFrame,
+  parseFrame,
+  type FrameHeader,
+} from "./protocol.ts";
+
+function frame(
+  overrides: Partial<FrameHeader> & Pick<FrameHeader, "k" | "blockLen" | "totalLen">,
+): Uint8Array {
+  const header: FrameHeader = {
+    sessionId: 1,
+    seq: 0,
+    payloadFnv: 0,
+    ...overrides,
+  };
+  return packFrame(header, new Uint8Array(header.blockLen));
+}
+
+test("parseFrame accepts a consistent single-block transfer", () => {
+  const bytes = frame({ k: 1, blockLen: 1000, totalLen: 800 });
+  const parsed = parseFrame(bytes);
+  assert.ok(parsed);
+  assert.equal(parsed.header.totalLen, 800);
+  assert.equal(parsed.block.length, 1000);
+});
+
+test("parseFrame accepts a full last block (totalLen === k * blockLen)", () => {
+  const bytes = frame({ k: 3, blockLen: 100, totalLen: 300 });
+  assert.ok(parseFrame(bytes));
+});
+
+test("parseFrame accepts a short last block", () => {
+  // 2 full blocks + 1 byte → k = 3, totalLen = 201
+  const bytes = frame({ k: 3, blockLen: 100, totalLen: 201 });
+  assert.ok(parseFrame(bytes));
+});
+
+test("parseFrame rejects the issue #1 DoS header (k=1, totalLen=0xFFFFFFFF)", () => {
+  const bytes = frame({ k: 1, blockLen: 1000, totalLen: 0xffffffff });
+  assert.equal(parseFrame(bytes), null);
+});
+
+test("parseFrame rejects totalLen that would need fewer blocks", () => {
+  // Claims k=3 but totalLen fits in 2 blocks.
+  const bytes = frame({ k: 3, blockLen: 100, totalLen: 200 });
+  assert.equal(parseFrame(bytes), null);
+});
+
+test("parseFrame rejects totalLen above k * blockLen", () => {
+  const bytes = frame({ k: 2, blockLen: 100, totalLen: 201 });
+  assert.equal(parseFrame(bytes), null);
+});
+
+test("parseFrame rejects totalLen above MAX_TOTAL_LEN even if consistent", () => {
+  const blockLen = 1024;
+  const k = Math.ceil((MAX_TOTAL_LEN + 1) / blockLen);
+  assert.ok(k * blockLen >= MAX_TOTAL_LEN + 1);
+  assert.ok(k <= 0xffff, "test k must fit in u16");
+  const bytes = frame({ k, blockLen, totalLen: MAX_TOTAL_LEN + 1 });
+  assert.equal(parseFrame(bytes), null);
+});
+
+test("parseFrame round-trips a legitimate packed frame", () => {
+  const payload = new Uint8Array(64).fill(7);
+  const header: FrameHeader = {
+    sessionId: 0xabcd,
+    seq: 42,
+    k: 1,
+    blockLen: payload.length,
+    totalLen: payload.length,
+    payloadFnv: 0x12345678,
+  };
+  const bytes = packFrame(header, payload);
+  assert.equal(bytes.length, HEADER_LEN + payload.length);
+  const parsed = parseFrame(bytes);
+  assert.ok(parsed);
+  assert.deepEqual({ ...parsed.header }, header);
+  assert.deepEqual([...parsed.block], [...payload]);
+});

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -16,6 +16,15 @@ export const HEADER_LEN = 20;
 const MAGIC0 = 0xd1;
 const MAGIC1 = 0x0c;
 
+/**
+ * Absolute ceiling on declared file size. Defense-in-depth against a
+ * self-consistent but absurd header (k and blockLen are independently
+ * attacker-controlled u16s, so k * blockLen can still approach ~4 GiB).
+ * Well above the PoC's 2 MB demo payload; raise intentionally if the
+ * product starts shipping larger transfers.
+ */
+export const MAX_TOTAL_LEN = 32 * 1024 * 1024;
+
 export interface FrameHeader {
   sessionId: number;
   seq: number;
@@ -56,6 +65,15 @@ export function parseFrame(
   };
   if (header.k === 0 || header.blockLen === 0 || header.totalLen === 0) return null;
   if (bytes.length !== HEADER_LEN + header.blockLen) return null;
+
+  // totalLen must match k blocks of blockLen: the last block may be short,
+  // so (k - 1) * blockLen < totalLen ≤ k * blockLen. Without this check a
+  // single hostile frame can declare totalLen ≈ 4 GiB with k = 1 and drive
+  // LTDecoder.assemble() to allocate that many bytes (see issue #1).
+  const cap = header.k * header.blockLen;
+  if (header.totalLen > cap || header.totalLen <= cap - header.blockLen) return null;
+  if (header.totalLen > MAX_TOTAL_LEN) return null;
+
   return { header, block: bytes.subarray(HEADER_LEN) };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "skipLibCheck": true,
     "types": ["vite/client"]
   },
-  "include": ["shared", "send", "receive"]
+  "include": ["shared", "send", "receive"],
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Closes the receiver memory-exhaustion DoS in #1: `parseFrame` now requires `totalLen` to be consistent with `k` and `blockLen`, and rejects sizes above `MAX_TOTAL_LEN` (32 MiB).

Without this, a single hostile QR frame can declare `k = 1`, `blockLen = 1000`, `totalLen = 0xFFFFFFFF` and drive `LTDecoder.assemble()` to allocate ~4 GiB.

### Validation added in `parseFrame`

```ts
const cap = header.k * header.blockLen;
if (header.totalLen > cap || header.totalLen <= cap - header.blockLen) return null;
if (header.totalLen > MAX_TOTAL_LEN) return null;
```

Legitimate sender headers (`totalLen = payload.length`, `k = ceil(totalLen / blockLen)`) satisfy the invariant by construction. The absolute ceiling is defense-in-depth for large but self-consistent `k × blockLen` products and can be raised when larger transfers ship.

## Test plan

- [x] `npm test` — 8 bounds / round-trip cases including the #1 PoC header
- [x] `npm run build` — `tsc` + Vite production build clean
- [ ] Smoke: send/receive the bundled demo image still completes

Fixes #1