### PR TITLE
fix: reject inconsistent totalLen in parseFrame (issue #1)

### DIFF
--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -15,6 +15,12 @@
 export const HEADER_LEN = 20;
 export const MAX_FILE_BYTES = 64 * 1024 * 1024;
 /**
+ * Absolute ceiling on declared frame `totalLen`. Same as MAX_FILE_BYTES so a
+ * self-consistent but absurd k×blockLen product cannot drive assemble() past
+ * the product file-size limit (see issue #1 / parseFrame).
+ */
+export const MAX_TOTAL_LEN = MAX_FILE_BYTES;
+/**
  * One place for the number, so the picker label, the rejection message and
  * packFile()'s own error can't drift apart. The HTML pulls it in as the
  * `%MAX_FILE_LABEL%` token (see htmlTokens() in vite.config.ts).
@@ -309,6 +315,15 @@ export function parseFrame(
   };
   if (header.k === 0 || header.blockLen === 0 || header.totalLen === 0) return null;
   if (bytes.length !== HEADER_LEN + header.blockLen) return null;
+
+  // totalLen must match k blocks of blockLen: the last block may be short, so
+  // (k - 1) * blockLen < totalLen ≤ k * blockLen. Without this a single hostile
+  // frame can declare totalLen ≈ 4 GiB with k = 1 and drive LTDecoder.assemble()
+  // to allocate that many bytes (issue #1).
+  const cap = header.k * header.blockLen;
+  if (header.totalLen > cap || header.totalLen <= cap - header.blockLen) return null;
+  if (header.totalLen > MAX_TOTAL_LEN) return null;
+
   return { header, block: bytes.subarray(HEADER_LEN) };
 }
 

--- a/tests/parse-frame-bounds.test.ts
+++ b/tests/parse-frame-bounds.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type FrameHeader,
+  HEADER_LEN,
+  MAX_TOTAL_LEN,
+  packFrame,
+  parseFrame,
+} from "../shared/protocol.ts";
+
+function frame(
+  overrides: Partial<FrameHeader> & Pick<FrameHeader, "k" | "blockLen" | "totalLen">,
+): Uint8Array {
+  const header: FrameHeader = {
+    sessionId: 1,
+    seq: 0,
+    payloadFnv: 0,
+    ...overrides,
+  };
+  return packFrame(header, new Uint8Array(header.blockLen));
+}
+
+test("parseFrame accepts a consistent single-block transfer", () => {
+  const bytes = frame({ k: 1, blockLen: 1000, totalLen: 800 });
+  const parsed = parseFrame(bytes);
+  assert.ok(parsed);
+  assert.equal(parsed!.header.totalLen, 800);
+  assert.equal(parsed!.block.length, 1000);
+});
+
+test("parseFrame accepts a full last block (totalLen === k * blockLen)", () => {
+  assert.ok(parseFrame(frame({ k: 3, blockLen: 100, totalLen: 300 })));
+});
+
+test("parseFrame accepts a short last block", () => {
+  assert.ok(parseFrame(frame({ k: 3, blockLen: 100, totalLen: 201 })));
+});
+
+test("parseFrame rejects the issue #1 DoS header (k=1, totalLen=0xFFFFFFFF)", () => {
+  assert.equal(parseFrame(frame({ k: 1, blockLen: 1000, totalLen: 0xffffffff })), null);
+});
+
+test("parseFrame rejects totalLen that would need fewer blocks", () => {
+  assert.equal(parseFrame(frame({ k: 3, blockLen: 100, totalLen: 200 })), null);
+});
+
+test("parseFrame rejects totalLen above k * blockLen", () => {
+  assert.equal(parseFrame(frame({ k: 2, blockLen: 100, totalLen: 201 })), null);
+});
+
+test("parseFrame rejects totalLen above MAX_TOTAL_LEN even if consistent", () => {
+  const blockLen = 4096;
+  const totalLen = MAX_TOTAL_LEN + 1;
+  const k = Math.ceil(totalLen / blockLen);
+  assert.ok(k <= 0xffff, "test k must fit in u16");
+  assert.ok(k * blockLen >= totalLen);
+  assert.ok(totalLen > (k - 1) * blockLen);
+  assert.equal(parseFrame(frame({ k, blockLen, totalLen })), null);
+});
+
+test("parseFrame round-trips a legitimate packed frame", () => {
+  const payload = new Uint8Array(64).fill(7);
+  const header: FrameHeader = {
+    sessionId: 0xabcd,
+    seq: 42,
+    k: 1,
+    blockLen: payload.length,
+    totalLen: payload.length,
+    payloadFnv: 0x12345678,
+  };
+  const bytes = packFrame(header, payload);
+  assert.equal(bytes.length, HEADER_LEN + payload.length);
+  const parsed = parseFrame(bytes);
+  assert.ok(parsed);
+  assert.deepEqual({ ...parsed!.header }, header);
+  assert.deepEqual([...parsed!.block], [...payload]);
+});

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -83,20 +83,21 @@ test("filenames that sanitise away fall back to a safe default", async () => {
 test("the frame header is byte-for-byte what the wire expects", () => {
   // 20-byte little-endian header, then the block. Both ends parse this without
   // negotiating, and standalone builds from older releases stay in circulation.
+  // totalLen must be consistent with k×blockLen (parseFrame rejects otherwise).
   const frame = packFrame(
     {
       sessionId: 0xbeef,
       seq: 0x01020304,
       k: 0x0111,
       blockLen: 6,
-      totalLen: 0x00fedcba,
+      totalLen: 1638, // 0x0111 * 6 — full last block
       payloadFnv: 0x89abcdef,
     },
     new Uint8Array([1, 2, 3, 4, 5, 6]),
   );
   assert.equal(
     [...frame].map((b) => b.toString(16).padStart(2, "0")).join(" "),
-    "d1 0c ef be 04 03 02 01 11 01 06 00 ba dc fe 00 ef cd ab 89 01 02 03 04 05 06",
+    "d1 0c ef be 04 03 02 01 11 01 06 00 66 06 00 00 ef cd ab 89 01 02 03 04 05 06",
   );
   assert.equal(frame.length, HEADER_LEN + 6);
 
@@ -107,7 +108,7 @@ test("the frame header is byte-for-byte what the wire expects", () => {
     seq: 0x01020304,
     k: 0x0111,
     blockLen: 6,
-    totalLen: 0x00fedcba,
+    totalLen: 1638,
     payloadFnv: 0x89abcdef,
   });
   assert.deepEqual(parsed.block, new Uint8Array([1, 2, 3, 4, 5, 6]));


### PR DESCRIPTION
## Summary
- Enforce `totalLen` consistency with `k × blockLen` and `MAX_TOTAL_LEN` in `parseFrame`
- Add boundary tests including the issue #1 DoS header (`k=1`, `totalLen=0xFFFFFFFF`)
- Adjust the wire-format golden test to use a self-consistent `totalLen`

Closes #1

## Test plan
- [x] `npm test` (includes `parse-frame-bounds`)
- [x] `npm run build`

## Notes
Large-file / multi-QR ideas in the issue comments are out of scope for this fix; please open separate issues if desired.


Made with [Cursor](https://cursor.com)