### PR TITLE
v0.5.1

### DIFF
--- a/docs/technical/platform-quirks.md
+++ b/docs/technical/platform-quirks.md
@@ -8,6 +8,8 @@ The hard-won details baked into the code, so nobody has to rediscover them.
 - **iOS may refuse a live `applyConstraints`.** The receiver keeps the running stream and says so rather than tearing down a transfer.
 - **Capabilities are probed, not UA-sniffed** (`shared/platform.ts`). Android Chrome exposes `torch`, `focusMode`, `frameRate.max` via `getCapabilities()`; iOS exposes none of them. Continuous autofocus is applied when available; unreachable fps options are disabled. `torch` is reported but deliberately unused — the sender is an emissive screen, a flashlight only adds glare.
 - **`requestVideoFrameCallback` chains outlive their stream** and resume on the next one; a generation counter prevents zombie capture loops.
+- **One camera at a time.** Phones will not open a second camera while one is live, so switching devices stops the current track *before* the new `getUserMedia` — which is why a refused switch needs an explicit reacquire fallback rather than keeping the stream it no longer has (`switchCamera` in `receive/main.ts`). And `enumerateDevices` labels are blank until permission is granted, which is why the camera picker fills in only after the first start.
+- **Auto camera selection picks the wrong lens on some phones.** `facingMode: environment` hands over the telephoto on a Huawei P30 Pro (blurry until the user backs across the room) and the front camera on others. Field reports, not speculation — the camera picker exists because auto cannot be trusted on every device.
 
 ## QR decoding
 

--- a/docs/user/receiving.md
+++ b/docs/user/receiving.md
@@ -22,7 +22,8 @@ Camera settings apply live while the camera runs; a device that refuses a live r
 
 | setting | default | notes |
 |---|---|---|
+| camera | auto | the device list fills in once the camera starts (browsers hide camera names until permission is granted); pick a specific one when auto grabs the wrong lens — front, or a telephoto — and the stream switches over live |
 | capture width | 1280 | 1920 costs decode time; 960 helps weak CPUs |
 | capture fps | 60 | iOS delivers 30 unless the exact rate is demanded — the app handles this |
-| decode workers | 2 | one WASM decoder per worker; busy workers drop frames, which the fountain absorbs |
+| decode workers | device max | one WASM decoder per worker; busy workers drop frames, which the fountain absorbs |
 | show received files automatically | on | the only setting that persists between sessions, and the only one read when a transfer *lands* rather than when the camera starts |

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -41,6 +41,7 @@ every QR code in view. See "Nothing happening?" above.
 
 ## Camera problems
 
+- **Wrong camera** — the front camera instead of the rear one, or a telephoto that stays blurry unless you stand across the room. Some phones hand the browser the wrong lens as "the" rear camera; pick the right one under **Receive settings → camera**. The list shows real camera names once the camera has started, and switching applies immediately, mid-transfer included.
 - **Permission denied** — tap the browser's permission prompt carefully; if you hit Block by accident, allow camera for the site and tap **Start camera** again (no reload needed).
 - **"camera needs a secure context"** — the page is being served over plain http. Browsers remove the camera API on insecure origins; serve over https (the dev server already does, self-signed) or use [decimen.app](https://decimen.app/).
 - **Standalone receiver file** — opening `decimen-receiver.html` from `file://` will not get a camera on iOS or Android. See [Install & offline](install-and-offline.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "decimen-optical-transfer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "decimen-optical-transfer",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decimen-optical-transfer",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "AGPL-3.0-or-later",
   "description": "Offline file and text transfer using fountain-coded animated QR codes — screen to camera, no network.",
   "type": "module",

--- a/receive/index.html
+++ b/receive/index.html
@@ -85,6 +85,12 @@
         <details class="settings" id="settings">
           <summary>Receive settings</summary>
           <div class="row">
+            <label class="camera-pick">camera
+              <!-- One option until the camera runs: browsers return blank
+                   device labels before permission is granted, so the real
+                   list is filled by populateCameraOptions() after start. -->
+              <select id="cfg-camera"><option value="" selected>auto</option></select>
+            </label>
             <label>capture width
               <select id="cfg-width"><option>960</option><option selected>1280</option><option>1920</option><option>2560</option><option>3840</option></select>
             </label>

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -61,6 +61,7 @@ const settingsEl = document.getElementById("settings")!;
 const cfgWidth = document.getElementById("cfg-width") as HTMLSelectElement;
 const cfgCapFps = document.getElementById("cfg-capfps") as HTMLSelectElement;
 const cfgWorkers = document.getElementById("cfg-workers") as HTMLSelectElement;
+const cfgCamera = document.getElementById("cfg-camera") as HTMLSelectElement;
 const cfgAutoShow = document.getElementById("cfg-autoshow") as HTMLInputElement;
 
 /**
@@ -444,6 +445,70 @@ function offerRetry(message: string) {
   showError(message);
 }
 
+/**
+ * The user's camera pick, or auto. Auto asks for the environment-facing camera
+ * and lets the browser choose a lens — a choice some phones get wrong: a
+ * Huawei P30 Pro hands over the telephoto (blurry until you back across the
+ * room), and some devices hand over the front camera outright. An explicit
+ * pick pins the exact device instead.
+ */
+function cameraSelection(): MediaTrackConstraints {
+  return cfgCamera.value
+    ? { deviceId: { exact: cfgCamera.value } }
+    : { facingMode: "environment" };
+}
+
+/** getUserMedia with the shared width/fps settings applied. Frame rate is
+ *  demanded exactly first — iOS hands back 30 fps after accepting a polite
+ *  request for 60 — and the ideal retry takes what the camera can give. */
+async function acquireCamera(selection: MediaTrackConstraints): Promise<MediaStream> {
+  const captureWidth = Number(cfgWidth.value);
+  const captureFps = Number(cfgCapFps.value);
+  const base: MediaTrackConstraints = {
+    ...selection,
+    width: { ideal: captureWidth },
+    height: { ideal: Math.round((captureWidth * 3) / 4) },
+  };
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: { ...base, frameRate: { exact: captureFps } },
+    });
+  } catch {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: { ...base, frameRate: { ideal: captureFps } },
+    });
+  }
+}
+
+/**
+ * Fill the camera <select> with the device's actual cameras.
+ *
+ * Runs after every successful acquisition, not at page load: enumerateDevices
+ * returns blank labels until camera permission is granted, and a list reading
+ * "camera 1 / camera 2" is exactly the guessing game the picker exists to end.
+ * The current pick survives the rebuild; a pick whose device vanished falls
+ * back to auto rather than leaving the select pointing at nothing.
+ */
+async function populateCameraOptions() {
+  let devices: MediaDeviceInfo[];
+  try {
+    devices = await navigator.mediaDevices.enumerateDevices();
+  } catch {
+    return; // no list, no picker — auto still works
+  }
+  const cameras = devices.filter((d) => d.kind === "videoinput");
+  // A single camera offers no choice: keep the plain auto-only select.
+  if (cameras.length < 2) return;
+  const chosen = cfgCamera.value;
+  cfgCamera.replaceChildren(
+    new Option("auto", ""),
+    ...cameras.map((d, i) => new Option(d.label || `camera ${i + 1}`, d.deviceId)),
+  );
+  cfgCamera.value = cameras.some((d) => d.deviceId === chosen) ? chosen : "";
+}
+
 async function start() {
   if (!navigator.mediaDevices?.getUserMedia) {
     // On insecure origins the API doesn't exist AT ALL — this is the plain-
@@ -454,35 +519,21 @@ async function start() {
     );
     return;
   }
-  const captureWidth = Number(cfgWidth.value);
-  const captureFps = Number(cfgCapFps.value);
   // Nothing on the page changes until the camera is actually running: the
   // error paths below all have to leave a usable Start button behind.
   startBtn.disabled = true;
   startBtn.textContent = "Starting…";
-  const base: MediaTrackConstraints = {
-    facingMode: "environment",
-    width: { ideal: captureWidth },
-    height: { ideal: Math.round((captureWidth * 3) / 4) },
-  };
   try {
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: false,
-        video: { ...base, frameRate: { exact: captureFps } },
-      });
-    } catch {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: false,
-        video: { ...base, frameRate: { ideal: captureFps } },
-      });
-    }
+    stream = await acquireCamera(cameraSelection());
   } catch (err) {
     const denied = err instanceof DOMException && err.name === "NotAllowedError";
+    const gone = err instanceof DOMException && err.name === "OverconstrainedError";
     offerRetry(
       denied
         ? "camera permission denied — allow it, then tap Start camera again."
-        : `camera: ${err instanceof Error ? err.message : String(err)}`,
+        : gone
+          ? "that camera is no longer available — set camera back to auto and tap Start camera."
+          : `camera: ${err instanceof Error ? err.message : String(err)}`,
     );
     return;
   }
@@ -503,11 +554,15 @@ async function start() {
   pool.resize(Number(cfgWorkers.value));
   reportCameraSettings();
   void applyCameraExtras();
+  void populateCameraOptions();
   if (!settingsWired) {
     settingsWired = true;
     for (const el of [cfgWidth, cfgCapFps, cfgWorkers]) {
       el.addEventListener("change", () => void applyReceiveSettings());
     }
+    // The camera pick is the one setting a live track cannot applyConstraints
+    // its way into — switching lenses means a fresh getUserMedia.
+    cfgCamera.addEventListener("change", () => void switchCamera());
   }
 
   noSignal.cameraStarted(performance.now());
@@ -543,15 +598,67 @@ async function applyCameraExtras() {
   if (caps.continuousFocus) {
     await applyAdvancedConstraint(track, { focusMode: "continuous" });
   }
-  if (caps.maxFrameRate) {
-    for (const option of Array.from(cfgCapFps.options)) {
-      option.disabled = Number(option.value) > caps.maxFrameRate;
+  // Unconditional loops, not gated on the cap existing: with a camera picker
+  // these limits change within a session (a telephoto's ceiling is not the
+  // wide lens's), and a gray-out left over from the last lens would misreport
+  // this one.
+  for (const option of Array.from(cfgCapFps.options)) {
+    option.disabled = caps.maxFrameRate ? Number(option.value) > caps.maxFrameRate : false;
+  }
+  for (const option of Array.from(cfgWidth.options)) {
+    option.disabled = caps.maxWidth ? Number(option.value) > caps.maxWidth : false;
+  }
+}
+
+/**
+ * Reacquire the camera for a new pick from the settings select.
+ *
+ * The current track is stopped FIRST: phones will not open a second camera
+ * while one is live, so the old one has to die before the new request — which
+ * is also why failure needs an explicit fallback instead of just keeping the
+ * stream we had. Decode state is untouched throughout; frames simply pause
+ * until the new camera delivers (requestVideoFrameCallback rides the video
+ * element, not the stream, so the capture loop survives the swap).
+ */
+async function switchCamera() {
+  if (done || !stream) return;
+  cfgCamera.disabled = true; // one switch at a time
+  const previous = stream.getVideoTracks()[0]?.getSettings().deviceId;
+  for (const track of stream.getTracks()) track.stop();
+  let refused = false;
+  try {
+    stream = await acquireCamera(cameraSelection());
+  } catch {
+    try {
+      // Any camera beats a dead receiver: back to the one that was running,
+      // or auto if even its id is gone.
+      stream = await acquireCamera(
+        previous ? { deviceId: { exact: previous } } : { facingMode: "environment" },
+      );
+      refused = true;
+    } catch {
+      // Both attempts failed — the hardware is wedged or was unplugged. Put
+      // the Start button back; decode state survives for a resumed session.
+      stream = null;
+      video.srcObject = null;
+      cfgCamera.disabled = false;
+      offerRetry("camera: could not restart after the switch — tap Start camera.");
+      return;
     }
   }
-  if (caps.maxWidth) {
-    for (const option of Array.from(cfgWidth.options)) {
-      option.disabled = Number(option.value) > caps.maxWidth;
-    }
+  cfgCamera.disabled = false;
+  video.srcObject = stream;
+  await video.play().catch(() => undefined);
+  syncPreviewAspect();
+  reportCameraSettings();
+  void applyCameraExtras();
+  await populateCameraOptions();
+  if (refused) {
+    // After reportCameraSettings wrote its normal line — the refusal is the
+    // more useful thing for the status line to say.
+    cameraActual.textContent = "that camera refused to start — kept the previous one";
+    cfgCamera.value =
+      previous && Array.from(cfgCamera.options).some((o) => o.value === previous) ? previous : "";
   }
 }
 

--- a/shared/style.css
+++ b/shared/style.css
@@ -352,6 +352,12 @@ details.settings input[type="checkbox"] {
   margin: 0;
   accent-color: var(--accent);
 }
+/* Camera names are prose ("Back Telephoto Camera"), not numbers like every
+   other option in the row — cap the select so a long label wraps the flex row
+   instead of stretching it off a phone screen. */
+details.settings label.camera-pick select {
+  max-width: 220px;
+}
 .settings-actual {
   margin: 10px 0 2px;
   padding-top: 9px;


### PR DESCRIPTION
Camera selector in Receive settings — auto camera selection grabs the wrong lens on some devices (P30 Pro telephoto, front-camera reports). Wire format unchanged; fully compatible with 0.5.0.