### PR TITLE
Improve receiver recovery and decode throughput

### DIFF
--- a/.agents/quality-gate
+++ b/.agents/quality-gate
@@ -1,0 +1,3 @@
+npm test
+npm run build:all
+git diff --check

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -21,6 +21,8 @@ Three pages, one shared core, a handful of single-purpose build plugins. No fram
 - `worker-pool.ts` — decode worker pool; busy workers drop frames, the fountain absorbs it.
 - `no-signal.ts` — pure timing policy for the "Nothing happening?" hint (short first delay, longer after dismissal).
 - `progress.ts` — frames-collected progress estimation and fountain-overhead model.
+- `decode-policy.ts` — pure crop/full-scan downscale and `tryHarder` policy.
+- `receiver-session.ts` — completion verification, race claims, and bounded duplicate filtering.
 - `send-settings.ts` — canonical tx settings lists; the sender's dropdowns and the no-signal advice both render from it.
 - `snippet.ts` — text-snippet container type.
 - `dialog.ts` — geometric backdrop-click close for `<dialog>`.

--- a/docs/technical/diagnostics.md
+++ b/docs/technical/diagnostics.md
@@ -58,9 +58,11 @@ sent from `finish()` while camera settings and pool size are still real):
   frames (capacity or tracking). High overhead *with* a high catch rate →
   blame the fountain, not the pipeline.
 - **Pipeline**: captures, drops from a busy pool, crops vs full scans,
-  decodes, `trackedAttempts`/`trackedDecodes` (hits/attempts is the
+  downscaled crop/full-scan counts, decodes,
+  `trackedAttempts`/`trackedDecodes` (hits/attempts is the
   decimen-codec fast path's real hit rate — zero attempts means the
-  quad/dim plumbing broke, not the decoder), `zeroRegionMs`/`degradedMs`
+  quad/dim plumbing broke, not the decoder), `resyncs` and machine-readable
+  `resyncReasons`, `zeroRegionMs`/`degradedMs`
   (time spent with tracking collapsed / below the expected code count).
 - **Environment**: worker count, requested vs actual camera settings,
   probed camera capabilities, device cores and UA.
@@ -79,6 +81,10 @@ sent from `finish()` while camera settings and pool size are still real):
    `framesRedundant` and `usefulOverhead`.
 4. `trackedDecodes/trackedAttempts` low? The fast path is missing — camera
    drift or quad quality; the crop pipeline is falling back to full decodes.
+5. `resyncs > 0`? A completed assembly failed FNV, container parsing, or
+   SHA-256 verification. The receiver replaced the spent fountain decoder and
+   kept capturing the same stream; inspect `resyncReasons` before blaming the
+   fountain.
 
 ## Benchmark records
 

--- a/docs/user/receiving.md
+++ b/docs/user/receiving.md
@@ -6,6 +6,10 @@ Fill the camera view with the code and prop the phone against something — auto
 
 Progress counts **frames collected**, not blocks solved — fountain decoding back-loads its solve cascade, so the bar is estimated from frame rate and only verified completion reaches 100%.
 
+If an assembled transfer fails verification, the receiver re-syncs and keeps
+receiving while the sender continues streaming. After repeated failures the
+status line recommends restarting the sender.
+
 ## When it lands
 
 - The file is verified against its SHA-256 before anything is offered.
@@ -24,6 +28,6 @@ Camera settings apply live while the camera runs; a device that refuses a live r
 |---|---|---|
 | camera | auto | the device list fills in once the camera starts (browsers hide camera names until permission is granted); pick a specific one when auto grabs the wrong lens — front, or a telephoto — and the stream switches over live |
 | capture width | 1280 | 1920 costs decode time; 960 helps weak CPUs |
-| capture fps | 60 | iOS delivers 30 unless the exact rate is demanded — the app handles this |
+| capture fps | 60 | 30, 60, 90, and 120 are offered; unsupported rates are disabled after the camera reports its capabilities |
 | decode workers | device max | one WASM decoder per worker; busy workers drop frames, which the fountain absorbs |
 | show received files automatically | on | the only setting that persists between sessions, and the only one read when a transfer *lands* rather than when the camera starts |

--- a/receive/index.html
+++ b/receive/index.html
@@ -96,7 +96,7 @@
               <select id="cfg-width"><option>960</option><option selected>1280</option><option>1920</option><option>2560</option><option>3840</option></select>
             </label>
             <label><span data-i18n="receive.settingCaptureFps">capture fps</span>
-              <select id="cfg-capfps"><option>30</option><option selected>60</option></select>
+              <select id="cfg-capfps"><option>30</option><option selected>60</option><option>90</option><option>120</option></select>
             </label>
             <label><span data-i18n="receive.settingDecodeWorkers">decode workers</span>
               <!-- No `selected`: main.ts defaults this to the device max after

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -13,6 +13,11 @@
 
 import { LTDecoder } from "../shared/fountain";
 import {
+  cropDownscale,
+  fullScanDownscale,
+  tryHarderForFullScan,
+} from "../shared/decode-policy";
+import {
   estimateTransferProgress,
   expectedFountainOverhead,
 } from "../shared/progress";
@@ -25,7 +30,6 @@ import {
   msg,
   verdictMessage,
 } from "../shared/i18n";
-import { OpticalError } from "../shared/optical-error";
 import { createDecodeWorker } from "./worker-factory";
 import { NoSignalHintTimer } from "../shared/no-signal";
 import {
@@ -35,15 +39,13 @@ import {
   type SymbolQuad,
 } from "../shared/worker-pool";
 import { isSnippet, snippetText } from "../shared/snippet";
+import { classifyFrame, parseFrame, streamIdentity, type FrameHeader, type OpticalFile } from "../shared/protocol";
 import {
-  classifyFrame,
-  fnv1a,
-  parseFrame,
-  streamIdentity,
-  unpackFile,
-  verifyFile,
-  type OpticalFile,
-} from "../shared/protocol";
+  CompletionClaims,
+  RecentFrameFilter,
+  verifyCompletedPayload,
+  type CompletionFailureReason,
+} from "../shared/receiver-session";
 import { NO_SIGNAL_HINT_FRAME_BYTES, NO_SIGNAL_HINT_TX_FPS } from "../shared/send-settings";
 import { statusLine } from "../shared/status-line";
 import { requestScreenWakeLock } from "../shared/wake-lock";
@@ -129,6 +131,8 @@ let reportSessionId = 0; // pairs this run with the sender's diagnostics post
 let startTs = 0;
 let captureGen = 0;
 let done = false;
+const completionClaims = new CompletionClaims();
+const recentFrames = new RecentFrameFilter();
 let settingsWired = false;
 let statsTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -163,6 +167,23 @@ let zeroRegionMs = 0; // transfer time spent with tracking fully collapsed
 let degradedMs = 0; // transfer time spent below the expected code count
 let minSeq = Infinity; // seq span ≈ what the sender emitted while we watched;
 let maxSeq = -1; //        framesNew / span is the fraction we actually caught
+// Run-level frame totals. A failed verification resyncs (replaces) the decoder
+// instance, whose per-instance counters would otherwise lose the frames
+// collected before the resync. These accumulate across instances and reset on a
+// new stream identity.
+let runFramesNew = 0;
+let runFramesDup = 0;
+let runFramesRedundant = 0;
+let exactDuplicatesSkipped = 0;
+let resyncs = 0;
+let resyncReasons: Record<CompletionFailureReason, number> = {
+  "payload-checksum": 0,
+  "container-invalid": 0,
+  "file-digest": 0,
+};
+// Downscale bookkeeping for the diagnostics report.
+let cropsDownscaled = 0;
+let fullScansDownscaled = 0;
 // One sample per stats tick (500 ms): elapsed s, framesNew, solved blocks,
 // live regions, capture fps, decode fps. The shape of a bad run — where it
 // stalled, when tracking collapsed — is invisible in run totals.
@@ -189,6 +210,10 @@ interface Region extends SymbolBox {
    *  detection entirely. Only ever set from real decodes. */
   quad?: SymbolQuad;
   dim?: number;
+  /** Observed density in capture px per module — the decode-downscale policy's
+   *  yardstick. A code that fills the frame at 20 px/module decodes fine at a
+   *  quarter of the pixels. */
+  ppm?: number;
 }
 const regions: Region[] = [];
 // Tried and reverted: a longer TTL for regions with a decode track record
@@ -228,6 +253,31 @@ function decodedCount(): number {
   return n;
 }
 
+/** Frame counters across the decoder instance AND any resynced predecessors,
+ *  so the live metrics, ETA and diagnostics never dip when a resync replaces
+ *  the decoder mid-run. */
+function totalFramesNew(): number {
+  return runFramesNew + (decoder?.framesNew ?? 0);
+}
+function totalFramesDup(): number {
+  return runFramesDup + exactDuplicatesSkipped + (decoder?.framesDup ?? 0);
+}
+function totalFramesRedundant(): number {
+  return runFramesRedundant + (decoder?.framesRedundant ?? 0);
+}
+
+/** The smallest px/module among live decoded regions — the densest code a full
+ *  scan has to keep readable. Undefined with nothing decoded: acquisition then
+ *  has no density yardstick and stays full-res. */
+function minLivePxPerModule(): number | undefined {
+  let min: number | undefined;
+  for (const r of regions) {
+    if (!r.decoded || !r.ppm) continue;
+    min = min === undefined ? r.ppm : Math.min(min, r.ppm);
+  }
+  return min;
+}
+
 function noteRegion(box: SymbolBox, now: number, decoded = true, info?: SymbolInfo): void {
   for (const r of regions) {
     const dx = Math.abs(box.x + box.w / 2 - (r.x + r.w / 2));
@@ -248,7 +298,10 @@ function noteRegion(box: SymbolBox, now: number, decoded = true, info?: SymbolIn
       Object.assign(r, box, { seen: now });
       r.decoded = true;
       if (info?.quad) r.quad = info.quad;
-      if (info?.modules) r.dim = info.modules;
+      if (info?.modules) {
+        r.dim = info.modules;
+        r.ppm = (r.w + r.h) / 2 / info.modules;
+      }
       return;
     }
   }
@@ -263,7 +316,14 @@ function noteRegion(box: SymbolBox, now: number, decoded = true, info?: SymbolIn
     const ratio = Math.max(box.w, box.h) / Math.max(reference.w, reference.h);
     if (ratio < 0.5 || ratio > 2) return;
   }
-  regions.push({ ...box, seen: now, decoded, quad: info?.quad, dim: info?.modules });
+  regions.push({
+    ...box,
+    seen: now,
+    decoded,
+    quad: info?.quad,
+    dim: info?.modules,
+    ppm: info?.modules ? (box.w + box.h) / 2 / info.modules : undefined,
+  });
   if (regions.length > MAX_REGIONS) {
     regions.sort((a, b) => Number(b.decoded) - Number(a.decoded) || b.seen - a.seen);
     regions.length = MAX_REGIONS;
@@ -709,7 +769,38 @@ function scheduleFrame(gen: number) {
 }
 
 const grab = document.createElement("canvas");
+/** Reused for software downscaling: source regions are drawn into this at a
+ *  reduced size and read back, so the worker decodes fewer pixels. Decode cost
+ *  tracks pixel area — a code that fills the frame at 20 px/module reads fine
+ *  at a quarter of that. The preview and overlay stay full-res; only the
+ *  worker's buffer shrinks. */
+const downscale = document.createElement("canvas");
 let frameId = 0;
+
+/** Copy a source region of `grab` into the downscale canvas at `scale` and
+ *  return the reduced pixels. Null when the region is too small to survive —
+ *  the caller skips that decode rather than feed the worker a sub-pixel code. */
+function readDownscaled(
+  sx: number,
+  sy: number,
+  sw: number,
+  sh: number,
+  scale: number,
+): ImageData | null {
+  const dw = Math.max(1, Math.floor(sw / scale));
+  const dh = Math.max(1, Math.floor(sh / scale));
+  if (dw < 32 || dh < 32) return null;
+  if (downscale.width !== dw || downscale.height !== dh) {
+    downscale.width = dw;
+    downscale.height = dh;
+  }
+  const dctx = downscale.getContext("2d", { willReadFrequently: true })!;
+  dctx.clearRect(0, 0, dw, dh);
+  dctx.imageSmoothingEnabled = true;
+  dctx.imageSmoothingQuality = "low";
+  dctx.drawImage(grab, sx, sy, sw, sh, 0, 0, dw, dh);
+  return dctx.getImageData(0, 0, dw, dh);
+}
 
 // GPU-side capture: createImageBitmap(video, crop) hands each worker a
 // transferable bitmap with NO main-thread pixel readback — the worker draws
@@ -834,11 +925,29 @@ function captureFrame() {
   if (fullScanDue) {
     lastFullScan = now;
     fullScans++;
-    const img = ctx.getImageData(0, 0, vw, vh);
-    pool.submit(
-      { id: frameId++, buf: img.data.buffer, w: vw, h: vh, ox: 0, oy: 0, full: true },
-      [img.data.buffer],
-    );
+    // The densest code on screen sets the floor a full scan must keep
+    // readable. With nothing decoded yet there is no density yardstick, so
+    // acquisition stays full-res. tryHarder follows the same policy: cold and
+    // degraded rescans need the extra detector passes; healthy background
+    // scans are re-verification, so they can afford to relax.
+    const minPpm = minLivePxPerModule();
+    const scale = minPpm === undefined ? 1 : fullScanDownscale(minPpm);
+    const tryHarder = tryHarderForFullScan(live, expectedRegions);
+    if (scale > 1) fullScansDownscaled++;
+    if (scale === 1) {
+      const img = ctx.getImageData(0, 0, vw, vh);
+      pool.submit(
+        { id: frameId++, buf: img.data.buffer, w: vw, h: vh, ox: 0, oy: 0, full: true, tryHarder },
+        [img.data.buffer],
+      );
+    } else {
+      const img = readDownscaled(0, 0, vw, vh, scale);
+      if (!img) return;
+      pool.submit(
+        { id: frameId++, buf: img.data.buffer, w: img.width, h: img.height, ox: 0, oy: 0, scale, full: true, tryHarder },
+        [img.data.buffer],
+      );
+    }
     return;
   }
   // One crop per known code, rotated so a short worker pool doesn't starve
@@ -857,12 +966,36 @@ function captureFrame() {
     const w = Math.min(vw - x, Math.ceil(r.w + 2 * pad));
     const h = Math.min(vh - y, Math.ceil(r.h + 2 * pad));
     if (w < 32 || h < 32) continue;
-    const img = ctx.getImageData(x, y, w, h);
+    // A code that fills most of the frame decodes fine at a fraction of the
+    // pixels: scale the crop down (decode cost tracks pixel area) and let the
+    // worker map positions back. Regions without a measured density stay
+    // full-res — no yardstick, no risk.
+    const scale = r.ppm ? cropDownscale(r.ppm) : 1;
+    let img: ImageData;
+    if (scale === 1) {
+      img = ctx.getImageData(x, y, w, h);
+    } else {
+      const small = readDownscaled(x, y, w, h, scale);
+      if (!small) continue;
+      img = small;
+      cropsDownscaled++;
+    }
     // The quad + dimension arm the worker's tracked fast path (detection
     // skipped entirely, 2× at V40); absent — or stale after a miss — the
     // worker falls back to the stock decoder on the same buffer.
     const taken = pool.submit(
-      { id: frameId++, buf: img.data.buffer, w, h, ox: x, oy: y, full: false, quad: r.quad, dim: r.dim },
+      {
+        id: frameId++,
+        buf: img.data.buffer,
+        w: img.width,
+        h: img.height,
+        ox: x,
+        oy: y,
+        scale,
+        full: false,
+        quad: r.quad,
+        dim: r.dim,
+      },
       [img.data.buffer],
     );
     if (!taken) break;
@@ -928,20 +1061,96 @@ function onDecoded(bytes: Uint8Array, box?: SymbolBox, info?: SymbolInfo) {
     streamKey = identity;
     reportSessionId = header.sessionId;
     startTs = performance.now();
+    // A fresh stream starts a fresh run: the previous one's frames no longer
+    // describe anything this receiver is working on.
+    runFramesNew = 0;
+    runFramesDup = 0;
+    runFramesRedundant = 0;
+    exactDuplicatesSkipped = 0;
+    resyncs = 0;
+    resyncReasons = { "payload-checksum": 0, "container-invalid": 0, "file-digest": 0 };
+    minSeq = Infinity;
+    maxSeq = -1;
+    recentFrames.clear();
     progressEl.style.display = "block";
     progressStatus.style.display = "flex";
+  }
+  if (recentFrames.isDuplicate(identity, header.seq)) {
+    exactDuplicatesSkipped++;
+    return;
   }
   minSeq = Math.min(minSeq, header.seq);
   maxSeq = Math.max(maxSeq, header.seq);
   decoder.addFrame(header.seq, block);
   updateProgressEstimate();
 
-  if (decoder.isComplete) {
-    const payload = decoder.assemble()!;
-    const seconds = (performance.now() - startTs) / 1000;
-    const ok = fnv1a(payload) === header.payloadFnv;
-    void finish(payload, ok, seconds);
+  if (decoder.isComplete && completionClaims.claim(identity)) {
+    void attemptCompletion(header, identity, decoder);
   }
+}
+
+/**
+ * The fountain finished assembling a payload. FNV-1a is a 32-bit pre-check,
+ * not a guarantee — a corrupted frame that RS accepted at ECC-L can poison a
+ * block and assemble to the wrong bytes without the fountain knowing. So the
+ * authoritative SHA-256 check runs BEFORE anything is torn down: on failure
+ * the receiver resyncs and keeps receiving (the sender is still streaming the
+ * same stream); only a verified payload pays for the teardown in finish().
+ */
+async function attemptCompletion(
+  header: FrameHeader,
+  identity: string,
+  completedDecoder: LTDecoder,
+): Promise<void> {
+  try {
+    const payload = completedDecoder.assemble();
+    if (!payload || done || streamKey !== identity) return;
+    const seconds = (performance.now() - startTs) / 1000;
+    const verification = await verifyCompletedPayload(payload, header.payloadFnv);
+    if (done || streamKey !== identity || decoder !== completedDecoder) return;
+    if (!verification.ok) {
+      resyncDecoder(verification.reason, completedDecoder);
+      return;
+    }
+    await finish(verification.file, payload, seconds);
+  } catch (error) {
+    // Verification failures are returned as values above. A throw here means
+    // the verified result failed while being rendered after teardown, so give
+    // the user a working restart path instead of an unhandled rejection.
+    if (done && streamKey === identity) {
+      bar.classList.add("error");
+      etaLabel.textContent = msg.receive.transferFailedShort;
+      showError(localizeError(error));
+      const heading = document.createElement("div");
+      heading.className = "failed";
+      heading.textContent = msg.receive.transferFailedShort;
+      const detail = document.createElement("p");
+      detail.className = "received-note";
+      detail.textContent = msg.receive.transferFailedDetail;
+      result.replaceChildren(heading, detail, restartButton(msg.receive.tryAgain));
+    }
+  } finally {
+    completionClaims.release(identity);
+  }
+}
+
+/**
+ * The assembled payload failed verification. The sender is still streaming the
+ * same stream (identity unchanged), so keep the pipeline alive and start a
+ * fresh decoder: LTDecoder locks up once complete (addFrame becomes a no-op),
+ * so the same instance would ignore every re-swept frame. Frames collected so
+ * far are folded into the run totals so the metrics stay continuous.
+ */
+function resyncDecoder(reason: CompletionFailureReason, completedDecoder: LTDecoder): void {
+  if (!decoder || decoder !== completedDecoder || done) return;
+  runFramesNew += decoder.framesNew;
+  runFramesDup += decoder.framesDup;
+  runFramesRedundant += decoder.framesRedundant;
+  resyncs++;
+  resyncReasons[reason]++;
+  const { k, blockLen, sessionId, totalLen } = decoder;
+  decoder = new LTDecoder(k, blockLen, sessionId, totalLen);
+  setStatus(msg.receive.resyncing + (resyncs >= 3 ? ` ${msg.receive.resyncRestartSender}` : ""));
 }
 
 function updateProgressEstimate() {
@@ -953,7 +1162,7 @@ function updateProgressEstimate() {
   // loss rate — a 30%-catch 4-code run showed 96% on the bar with half the
   // blocks outstanding, then "finished early". framesRedundant subtracts
   // exactly those empty arrivals.
-  const usefulFrames = decoder.framesNew - decoder.framesRedundant;
+  const usefulFrames = totalFramesNew() - totalFramesRedundant();
   const estimate = estimateTransferProgress(
     decoder.k,
     usefulFrames,
@@ -971,15 +1180,15 @@ function updateProgressEstimate() {
   );
   // Held back for the first few frames — a two-frame sample reads wildly wrong.
   const rate =
-    decoder.framesNew >= 4
+    totalFramesNew() >= 4
       ? ` · ${msg.units.kbPerSecond(fmtNumber(goodputKbs(elapsed), 1, 1))}`
       : "";
   etaLabel.textContent =
     (estimate.etaSeconds === undefined
       ? estimate.phase === "decoding"
-        ? msg.receive.framesDecoding(fmtInt(decoder.framesNew))
+        ? msg.receive.framesDecoding(fmtInt(totalFramesNew()))
         : msg.receive.estimatingTime
-      : msg.receive.aboutEta(formatDurationL(estimate.etaSeconds), fmtInt(decoder.framesNew))) +
+      : msg.receive.aboutEta(formatDurationL(estimate.etaSeconds), fmtInt(totalFramesNew()))) +
     rate;
 }
 
@@ -990,14 +1199,20 @@ function updateProgressEstimate() {
 function goodputKbs(elapsed: number): number {
   if (!decoder) return 0;
   return (
-    ((decoder.framesNew - decoder.framesRedundant) * decoder.blockLen) /
+    ((totalFramesNew() - totalFramesRedundant()) * decoder.blockLen) /
     expectedFountainOverhead(decoder.k) /
     1024 /
     Math.max(0.1, elapsed)
   );
 }
 
-async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
+/**
+ * Success-only completion: the payload has passed FNV + SHA-256. Tears the
+ * pipeline down (camera, stats timer, worker pool), posts the diagnostics
+ * report, and renders the recovered file. Failures never reach here —
+ * attemptCompletion() resyncs the decoder and keeps receiving.
+ */
+async function finish(file: OpticalFile, container: Uint8Array, seconds: number) {
   done = true;
   captureGen++;
   // npm run diagnostics: one JSON report per completed run, POSTed to the dev
@@ -1014,7 +1229,7 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
     // catch rate means the receiver missed displayed frames (capacity or
     // tracking); overhead high with a high catch rate blames the fountain.
     const seqSpan = maxSeq >= minSeq ? maxSeq - minSeq + 1 : 0;
-    const parsed = (decoder?.framesNew ?? 0) + (decoder?.framesDup ?? 0);
+    const parsed = totalFramesNew() + totalFramesDup();
     void fetch("/__diagnostics", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -1022,7 +1237,7 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
         role: "receiver",
         when: new Date().toISOString(),
         sessionId: reportSessionId,
-        ok: hashOk,
+        ok: true,
         seconds: Number(seconds.toFixed(2)),
         acquisitionSeconds: cameraStartedTs
           ? Number(((startTs - cameraStartedTs) / 1000).toFixed(2))
@@ -1037,12 +1252,12 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
         fountain: {
           k: decoder?.k,
           blockLen: decoder?.blockLen,
-          framesNew: decoder?.framesNew,
-          framesDup: decoder?.framesDup,
-          framesRedundant: decoder?.framesRedundant,
-          overhead: decoder ? Number((decoder.framesNew / decoder.k).toFixed(2)) : null,
+          framesNew: totalFramesNew(),
+          framesDup: totalFramesDup(),
+          framesRedundant: totalFramesRedundant(),
+          overhead: decoder ? Number((totalFramesNew() / decoder.k).toFixed(2)) : null,
           usefulOverhead: decoder
-            ? Number(((decoder.framesNew - decoder.framesRedundant) / decoder.k).toFixed(2))
+            ? Number(((totalFramesNew() - totalFramesRedundant()) / decoder.k).toFixed(2))
             : null,
           seqSpan,
           catchRate: seqSpan ? Number((parsed / seqSpan).toFixed(3)) : null,
@@ -1053,10 +1268,14 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
           captures: totalCaptures,
           capturesDroppedPoolBusy: capturesDropped,
           cropsSubmitted,
+          cropsDownscaled,
           fullScans,
+          fullScansDownscaled,
           decodes: totalDecodes,
           trackedAttempts,
           trackedDecodes,
+          resyncs,
+          resyncReasons,
           zeroRegionMs,
           degradedMs,
         },
@@ -1100,85 +1319,65 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
   bar.style.width = "100%";
   progressEl.setAttribute("aria-valuenow", "100");
   etaLabel.textContent = msg.receive.etaTotal(formatDurationL(seconds));
-  try {
-    if (!hashOk) throw new OpticalError("streamChecksumMismatch");
-    const file = await unpackFile(container);
-    if (!(await verifyFile(file))) throw new OpticalError("sha256Failed");
-
-    // The container carries its own media type, so the receiver never has to be
-    // told in advance whether a file or a text snippet is coming.
-    const runStats = (sizeLabel: string): string =>
-      [
-        msg.receive.fileStats(
-          sizeLabel,
-          msg.units.secondsValue(fmtNumber(seconds, 1, 1)),
-          msg.units.kbPerSecond(fmtNumber(container.length / 1024 / seconds, 1, 1)),
-        ),
-        ...(file.compression === "gzip" ? [msg.receive.gzipDecompressed] : []),
-        msg.receive.shaVerified,
-      ].join(" · ");
-    if (isSnippet(file)) {
-      progressLabel.textContent = msg.receive.recoveredText;
-      setStatus("");
-      showSnippet(snippetText(file), runStats(msg.receive.textLabel), cfgAutoShow.checked);
-      return;
-    }
-
-    progressLabel.textContent = msg.receive.recoveredFile;
-    const kb = Math.round(file.bytes.length / 1024);
-    // The run's numbers belong under the heading, not up in the camera status
-    // line — which is done for good and goes quiet.
+  // The container carries its own media type, so the receiver never has to be
+  // told in advance whether a file or a text snippet is coming.
+  const runStats = (sizeLabel: string): string =>
+    [
+      msg.receive.fileStats(
+        sizeLabel,
+        msg.units.secondsValue(fmtNumber(seconds, 1, 1)),
+        msg.units.kbPerSecond(fmtNumber(container.length / 1024 / seconds, 1, 1)),
+      ),
+      ...(file.compression === "gzip" ? [msg.receive.gzipDecompressed] : []),
+      msg.receive.shaVerified,
+    ].join(" · ");
+  if (isSnippet(file)) {
+    progressLabel.textContent = msg.receive.recoveredText;
     setStatus("");
-    const summary = document.createElement("p");
-    summary.className = "hint";
-    summary.textContent = runStats(`${fmtInt(kb)} ${msg.units.kilobytes}`);
-    const heading = document.createElement("div");
-    heading.className = "done";
-    heading.textContent = msg.receive.transferComplete;
-    const url = URL.createObjectURL(new Blob([file.bytes as BlobPart], { type: file.type }));
-    const download = document.createElement("a");
-    download.className = "download";
-    download.href = url;
-    download.download = file.name;
-    download.textContent = msg.receive.saveFile(file.name);
-    // Reading order of the finished page: heading, the run's numbers, the
-    // thing that arrived, Save under it, "Receive another file", and the
-    // Transfer summary panel last in its natural spot after #result.
-    result.replaceChildren(heading, summary);
-    const actions = document.createElement("div");
-    actions.className = "note-actions";
-    actions.append(download);
-    const endActions = document.createElement("div");
-    endActions.className = "note-actions pair";
-    endActions.append(restartButton(msg.receive.receiveAnother));
-    if (isPreviewable(file.type)) {
-      // Saving is unaffected either way — `download` above hangs off the blob
-      // URL, which needs nothing on disk. Only the preview is in question.
-      result.append(
-        cfgAutoShow.checked
-          ? await previewElement(file, url)
-          : revealButton(file, url, endActions),
-      );
-    }
-    result.append(actions, endActions);
-    await offerCacheClear(endActions);
-    const support = supportLink();
-    if (support) result.append(support);
-  } catch (error) {
-    // Everything is already torn down by this point, so the only way back to a
-    // live receiver is a reload. Offer it: a failed checksum used to leave the
-    // page dead with nothing but an error string on it.
-    bar.classList.add("error");
-    etaLabel.textContent = msg.receive.transferFailedShort;
-    showError(localizeError(error));
-    const heading = document.createElement("div");
-    heading.className = "failed";
-    heading.textContent = msg.receive.transferFailedShort;
-    const detail = document.createElement("p");
-    detail.className = "received-note";
-    detail.textContent = msg.receive.transferFailedDetail;
-    result.replaceChildren(heading, detail, restartButton(msg.receive.tryAgain));
+    showSnippet(snippetText(file), runStats(msg.receive.textLabel), cfgAutoShow.checked);
+    return;
   }
+
+  progressLabel.textContent = msg.receive.recoveredFile;
+  const kb = Math.round(file.bytes.length / 1024);
+  // The run's numbers belong under the heading, not up in the camera status
+  // line — which is done for good and goes quiet.
+  setStatus("");
+  const summary = document.createElement("p");
+  summary.className = "hint";
+  summary.textContent = runStats(`${fmtInt(kb)} ${msg.units.kilobytes}`);
+  const heading = document.createElement("div");
+  heading.className = "done";
+  heading.textContent = msg.receive.transferComplete;
+  const url = URL.createObjectURL(new Blob([file.bytes as BlobPart], { type: file.type }));
+  const download = document.createElement("a");
+  download.className = "download";
+  download.href = url;
+  download.download = file.name;
+  download.textContent = msg.receive.saveFile(file.name);
+  // Reading order of the finished page: heading, the run's numbers, the
+  // thing that arrived, Save under it, "Receive another file", and the
+  // Transfer summary panel last in its natural spot after #result.
+  result.replaceChildren(heading, summary);
+  const actions = document.createElement("div");
+  actions.className = "note-actions";
+  actions.append(download);
+  const endActions = document.createElement("div");
+  endActions.className = "note-actions pair";
+  endActions.append(restartButton(msg.receive.receiveAnother));
+  if (isPreviewable(file.type)) {
+    // Saving is unaffected either way: `download` above hangs off the blob
+    // URL, which needs nothing on disk. Only the preview is in question.
+    result.append(
+      cfgAutoShow.checked
+        ? await previewElement(file, url)
+        : revealButton(file, url, endActions),
+    );
+  }
+  result.append(actions, endActions);
+  await offerCacheClear(endActions);
+  const support = supportLink();
+  if (support) result.append(support);
 }
 
 /** Media types that put themselves on screen, and so are what the auto-show
@@ -1433,7 +1632,7 @@ function updateStats() {
   if (timeline.length < TIMELINE_MAX_SAMPLES) {
     timeline.push([
       Number(elapsed.toFixed(1)),
-      decoder.framesNew,
+      totalFramesNew(),
       decoder.solvedCount,
       liveNow,
       regions.length,
@@ -1445,7 +1644,7 @@ function updateStats() {
   updateProgressEstimate();
   metric("m-rate").textContent = msg.units.kbPerSecond(fmtNumber(goodputKbs(elapsed), 1, 1));
   metric("m-time").textContent = msg.units.secondsValue(fmtInt(elapsed));
-  metric("m-frames").textContent = `${decoder.framesNew}/${decoder.framesDup}`;
+  metric("m-frames").textContent = `${totalFramesNew()}/${totalFramesDup()}`;
   metric("m-k").textContent = String(decoder.k);
   metric("m-block").textContent = `${fmtInt(decoder.blockLen)} ${msg.units.bytes}`;
   metric("m-payload").textContent = `${fmtInt(Math.round(decoder.totalLen / 1024))} ${msg.units.kilobytes}`;

--- a/receive/worker.ts
+++ b/receive/worker.ts
@@ -28,18 +28,25 @@ const ctx = self as unknown as {
 };
 
 /** Axis-aligned bounds of a symbol quad, shifted into capture coordinates by
- *  the crop offset — the receiver uses these to crop the next frames. */
-function boundsOf(p: DecimenQuad, ox: number, oy: number) {
+ *  the crop offset and the decode downscale — the receiver uses these to crop
+ *  the next frames. The decoder reports in buffer pixels; each buffer pixel is
+ *  `scale` capture pixels wide, so the mapping is ox + x*scale. */
+function boundsOf(p: DecimenQuad, ox: number, oy: number, scale: number) {
   const xs = [p.topLeft.x, p.topRight.x, p.bottomRight.x, p.bottomLeft.x];
   const ys = [p.topLeft.y, p.topRight.y, p.bottomRight.y, p.bottomLeft.y];
   const x = Math.min(...xs);
   const y = Math.min(...ys);
-  return { x: ox + x, y: oy + y, w: Math.max(...xs) - x, h: Math.max(...ys) - y };
+  return {
+    x: ox + x * scale,
+    y: oy + y * scale,
+    w: (Math.max(...xs) - x) * scale,
+    h: (Math.max(...ys) - y) * scale,
+  };
 }
 
 /** The full quad in capture coordinates — the tracked path's anchor. */
-function shifted(p: DecimenQuad, ox: number, oy: number): DecimenQuad {
-  const s = (pt: { x: number; y: number }) => ({ x: pt.x + ox, y: pt.y + oy });
+function shifted(p: DecimenQuad, ox: number, oy: number, scale: number): DecimenQuad {
+  const s = (pt: { x: number; y: number }) => ({ x: ox + pt.x * scale, y: oy + pt.y * scale });
   return {
     topLeft: s(p.topLeft),
     topRight: s(p.topRight),
@@ -72,9 +79,9 @@ function pixelsOf(buf: ArrayBuffer | undefined, bitmap: ImageBitmap | undefined,
 }
 
 ctx.onmessage = async (e: MessageEvent) => {
-  const { id, buf, bitmap, w = 0, h = 0, ox = 0, oy = 0, full = true, quad, dim } = e.data as {
+  const { id, buf, bitmap, w = 0, h = 0, ox = 0, oy = 0, scale = 1, full = true, quad, dim, tryHarder = true } = e.data as {
     id: number;
-    /** Readback-fallback capture: raw RGBA. */
+    /** Readback-fallback capture: raw RGBA, already downscaled. */
     buf?: ArrayBuffer;
     /** Bitmap capture: GPU-cropped, pixels read on this thread. */
     bitmap?: ImageBitmap;
@@ -83,12 +90,17 @@ ctx.onmessage = async (e: MessageEvent) => {
     /** Crop origin within the capture, for mapping positions back. */
     ox?: number;
     oy?: number;
+    /** Decode downscale: each buffer pixel is this many capture pixels.
+     *  Positions come back in buffer pixels and are scaled up on the way out. */
+    scale?: number;
     /** Full-frame scan (up to a 3×3 grid) vs a single-code crop. */
     full?: boolean;
     /** The region's last decoded quad, capture coordinates — tracked path. */
     quad?: DecimenQuad;
     /** The stream's QR dimension in modules — tracked path. */
     dim?: number;
+    /** Whether a full scan may pay for the slower detector (crops always can). */
+    tryHarder?: boolean;
   };
   const zx = await ready;
   const pixels = pixelsOf(buf, bitmap, w, h);
@@ -106,18 +118,20 @@ ctx.onmessage = async (e: MessageEvent) => {
     let trackedAttempted = false;
     if (!full && quad && dim) {
       trackedAttempted = true;
+      // The quad arrives in capture coordinates; the buffer is downscaled.
+      const q = (pt: { x: number; y: number }) => ({ x: (pt.x - ox) / scale, y: (pt.y - oy) / scale });
       const r = zx.readTracked(
         ptr, pw, ph, dim,
-        quad.topLeft.x - ox, quad.topLeft.y - oy,
-        quad.topRight.x - ox, quad.topRight.y - oy,
-        quad.bottomRight.x - ox, quad.bottomRight.y - oy,
-        quad.bottomLeft.x - ox, quad.bottomLeft.y - oy,
+        q(quad.topLeft).x, q(quad.topLeft).y,
+        q(quad.topRight).x, q(quad.topRight).y,
+        q(quad.bottomRight).x, q(quad.bottomRight).y,
+        q(quad.bottomLeft).x, q(quad.bottomLeft).y,
       );
       if (r.valid && r.bytes.length > 0) {
         symbols.push({
           bytes: r.bytes,
-          box: boundsOf(r.position, ox, oy),
-          quad: shifted(r.position, ox, oy),
+          box: boundsOf(r.position, ox, oy, scale),
+          quad: shifted(r.position, ox, oy, scale),
           modules: r.modules,
           tracked: true,
         });
@@ -128,16 +142,19 @@ ctx.onmessage = async (e: MessageEvent) => {
     if (!trackedHit) {
       // Full scans get returnErrors (sightings live there — error results
       // COUNT against the symbol cap, hence the headroom above 9 codes) and a
-      // crop fallback stays in the cheapest configuration. tryHarder stays on
-      // everywhere: real marginal captures are where it earns its keep.
-      const vec = zx.readFull(ptr, pw, ph, true, full ? 12 : 2, full);
+      // crop fallback stays in the cheapest configuration. tryHarder is a
+      // policy decision made upstream (receive/main.ts): acquisition and
+      // degraded rescans need the extra passes; healthy background scans save
+      // the time. Crops default to true because their whole job is re-anchoring
+      // a tracked miss.
+      const vec = zx.readFull(ptr, pw, ph, tryHarder, full ? 12 : 2, full);
       for (let i = 0; i < vec.size(); i++) {
         const r = vec.get(i);
         if (r.valid && r.bytes.length > 0) {
           symbols.push({
             bytes: r.bytes,
-            box: boundsOf(r.position, ox, oy),
-            quad: shifted(r.position, ox, oy),
+            box: boundsOf(r.position, ox, oy, scale),
+            quad: shifted(r.position, ox, oy, scale),
             modules: r.modules,
             tracked: false,
           });
@@ -146,7 +163,7 @@ ctx.onmessage = async (e: MessageEvent) => {
           // the ECC budget) is still a fix on where a code sits — the
           // receiver aims a crop there, and crops decode where full frames
           // fail. Positions stay pixel-accurate through a ChecksumError.
-          const box = boundsOf(r.position, ox, oy);
+          const box = boundsOf(r.position, ox, oy, scale);
           if (box.w > 0 && box.h > 0) sightings.push(box);
         }
       }

--- a/shared/decode-policy.ts
+++ b/shared/decode-policy.ts
@@ -1,0 +1,65 @@
+// Decode-side tuning policy: how much to shrink each decode, and when to pay
+// for tryHarder.
+//
+// Decode cost scales with pixel area — binarization and the detector both walk
+// the whole buffer — but the decoder only needs ~3–5 px per QR module to
+// sample the grid. A code that fills half a 1280×960 capture yields a
+// ~1200×1200 crop being binarized and (on a tracked miss) full-detected for a
+// symbol that reads fine at a third of that. Scaling the buffer down before
+// handing it to the worker trades a cheap bilinear pass for a ~scale² cut in
+// the expensive one.
+//
+// Pure and DOM-free so it can be golden-tested in Node.
+//
+// The downscale is applied at decode time to the buffer the worker receives,
+// NOT by renegotiating the camera. Renegotiating would change the capture
+// resolution mid-stream — invalidating region coordinates, forcing
+// re-acquisition, and in many cases dropping the sensor's full quality for
+// the whole stream. This is per-frame, reversible, and keeps the preview and
+// overlay at full resolution.
+
+/** Modules the decoder can work with after downscaling. zxing's tracked path
+ *  samples a grid and its full path re-detects, so ~5 px/module is comfortable
+ *  for both. Keep it a hair above the minimum for motion-blur and focus
+ *  softness margins. */
+export const TARGET_PX_PER_MODULE = 5;
+/** Never downscale past this factor — a 4× shrink of a small code turns into
+ *  sub-pixel module widths and the decode fails for no reason. */
+export const MAX_DOWNSCALE = 4;
+
+/** The largest scale that keeps a code readable: target px/module divided into
+ *  the observed density, floored to an integer and clamped to [1, MAX]. */
+export function downscaleForPxPerModule(pxPerModule: number): number {
+  if (!Number.isFinite(pxPerModule) || pxPerModule <= 0) return 1;
+  return Math.min(MAX_DOWNSCALE, Math.max(1, Math.floor(pxPerModule / TARGET_PX_PER_MODULE)));
+}
+
+/** Scale for a single-code crop. `dim` is the QR dimension in modules; the
+ *  observed density is the region's average px/module. */
+export function cropDownscale(regionPxPerModule: number): number {
+  return downscaleForPxPerModule(regionPxPerModule);
+}
+
+/** Scale for a full-frame scan, driven by the smallest live code — the
+ *  scan has to keep the densest target on screen readable. With nothing
+ *  decoded yet there is no density yardstick, so acquisition scans stay
+ *  full-res: the receiver can't risk missing a small far-away code. */
+export function fullScanDownscale(minLivePxPerModule: number): number {
+  return downscaleForPxPerModule(minLivePxPerModule);
+}
+
+/** Whether a full scan should pay for the slower detector. Full scans are the
+ *  reacquisition path: cold (nothing live) and degraded (a code went missing)
+ *  both NEED the extra passes, so tryHarder stays on there. When every code is
+ *  live the scans are background re-verification — crops hold the lock, so a
+ *  relaxed miss costs nothing. */
+export function tryHarderForFullScan(liveDecodedRegions: number, expectedRegions: number): boolean {
+  return liveDecodedRegions === 0 || liveDecodedRegions < expectedRegions;
+}
+
+/** A downscaled buffer is only worth decoding if it is still large enough to
+ *  carry the symbol. Guards the crop path's "w/scale ≥ 32" rule so the
+ *  arithmetic lives next to the policy that produced it. */
+export function downsizedDimension(dimension: number, scale: number): number {
+  return Math.max(1, Math.floor(dimension / scale));
+}

--- a/shared/i18n/locales/ar.ts
+++ b/shared/i18n/locales/ar.ts
@@ -178,6 +178,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} من الإطارات · جارٍ فك الترميز`,
     aboutEta: (duration, frames) => `حوالي ${duration} · ${frames} من الإطارات`,
     etaTotal: (duration) => `${duration} إجمالًا`,
+    resyncing: "لم تجتز البيانات المستعادة التحقق. تجري إعادة المزامنة والمتابعة…",
+    resyncRestartSender: "إذا تكرر ذلك، فأعد تشغيل المرسِل.",
     transferFailedShort: "فشل النقل",
     transferFailedDetail:
       "لم يخرج من ذلك البث شيء صالح للاستخدام. أعد تشغيل المرسِل ثم امسحه من جديد — " +

--- a/shared/i18n/locales/de.ts
+++ b/shared/i18n/locales/de.ts
@@ -186,6 +186,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} Frames · wird decodiert`,
     aboutEta: (duration, frames) => `Noch etwa ${duration} · ${frames} Frames`,
     etaTotal: (duration) => `${duration} gesamt`,
+    resyncing: "Die wiederhergestellten Daten konnten nicht bestätigt werden. Synchronisierung läuft erneut…",
+    resyncRestartSender: "Wenn das weiter passiert, starten Sie den Sender neu.",
     transferFailedShort: "Übertragung fehlgeschlagen",
     transferFailedDetail:
       "Aus diesem Stream kam nichts Brauchbares. Starten Sie den Sender neu und scannen Sie " +

--- a/shared/i18n/locales/en.ts
+++ b/shared/i18n/locales/en.ts
@@ -180,6 +180,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} frames · decoding`,
     aboutEta: (duration, frames) => `About ${duration} · ${frames} frames`,
     etaTotal: (duration) => `${duration} total`,
+    resyncing: "Recovered bytes did not verify. Re-syncing and continuing…",
+    resyncRestartSender: "If this keeps happening, restart the sender.",
     transferFailedShort: "Transfer failed",
     transferFailedDetail:
       "Nothing usable came out of that stream. Restart the sender, then scan it again — " +

--- a/shared/i18n/locales/es.ts
+++ b/shared/i18n/locales/es.ts
@@ -182,6 +182,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} fotogramas · decodificando`,
     aboutEta: (duration, frames) => `Aprox. ${duration} · ${frames} fotogramas`,
     etaTotal: (duration) => `${duration} en total`,
+    resyncing: "Los datos recuperados no superaron la verificación. Resincronizando y continuando…",
+    resyncRestartSender: "Si esto sigue ocurriendo, reinicie el emisor.",
     transferFailedShort: "Transferencia fallida",
     transferFailedDetail:
       "De esa transmisión no salió nada utilizable. Reinicie el emisor y vuelva a escanear — " +

--- a/shared/i18n/locales/fr.ts
+++ b/shared/i18n/locales/fr.ts
@@ -194,6 +194,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} trames · décodage`,
     aboutEta: (duration, frames) => `Environ ${duration} · ${frames} trames`,
     etaTotal: (duration) => `${duration} au total`,
+    resyncing: "Les données récupérées n’ont pas été validées. Resynchronisation en cours…",
+    resyncRestartSender: "Si cela continue, redémarrez l’expéditeur.",
     transferFailedShort: "Échec du transfert",
     transferFailedDetail:
       "Rien d’utilisable n’est sorti de ce flux. Redémarrez l’expéditeur, puis scannez à " +

--- a/shared/i18n/locales/hi.ts
+++ b/shared/i18n/locales/hi.ts
@@ -179,6 +179,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} फ़्रेम · डिकोड जारी`,
     aboutEta: (duration, frames) => `लगभग ${duration} · ${frames} फ़्रेम`,
     etaTotal: (duration) => `कुल ${duration}`,
+    resyncing: "रिकवर हुए डेटा का सत्यापन नहीं हुआ। फ़िर से सिंक करके जारी रखा जा रहा है…",
+    resyncRestartSender: "अगर यह बार-बार हो, तो भेजने वाले को दोबारा शुरू करें।",
     transferFailedShort: "ट्रांसफ़र विफल",
     transferFailedDetail:
       "उस स्ट्रीम से कुछ भी काम का नहीं निकला। भेजने वाले को दोबारा शुरू करके फिर से स्कैन करें — " +

--- a/shared/i18n/locales/it.ts
+++ b/shared/i18n/locales/it.ts
@@ -188,6 +188,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} frame · decodifica in corso`,
     aboutEta: (duration, frames) => `Circa ${duration} · ${frames} frame`,
     etaTotal: (duration) => `${duration} in totale`,
+    resyncing: "I dati recuperati non hanno superato la verifica. Nuova sincronizzazione in corso…",
+    resyncRestartSender: "Se continua a succedere, riavvia il mittente.",
     transferFailedShort: "Trasferimento non riuscito",
     transferFailedDetail:
       "Da quel flusso non è uscito nulla di utilizzabile. Riavvia il mittente e scansiona " +

--- a/shared/i18n/locales/ja.ts
+++ b/shared/i18n/locales/ja.ts
@@ -183,6 +183,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} フレーム · デコード中`,
     aboutEta: (duration, frames) => `約 ${duration} · ${frames} フレーム`,
     etaTotal: (duration) => `合計 ${duration}`,
+    resyncing: "復元データの検証に失敗しました。再同期して続行します…",
+    resyncRestartSender: "繰り返し発生する場合は、送信側を再起動してください。",
     transferFailedShort: "転送失敗",
     transferFailedDetail:
       "このストリームからは有効なデータを復元できませんでした。送信側を再起動して、もう一度スキャンしてください。" +

--- a/shared/i18n/locales/ko.ts
+++ b/shared/i18n/locales/ko.ts
@@ -180,6 +180,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} 프레임 · 디코딩 중`,
     aboutEta: (duration, frames) => `약 ${duration} · ${frames} 프레임`,
     etaTotal: (duration) => `총 ${duration}`,
+    resyncing: "복구한 데이터를 검증하지 못했습니다. 다시 동기화하며 계속합니다…",
+    resyncRestartSender: "계속 발생하면 보내는 쪽을 다시 시작하세요.",
     transferFailedShort: "전송 실패",
     transferFailedDetail:
       "이 스트림에서는 쓸 수 있는 데이터가 나오지 않았습니다. 보내는 쪽을 다시 시작한 뒤 " +

--- a/shared/i18n/locales/pt-br.ts
+++ b/shared/i18n/locales/pt-br.ts
@@ -179,6 +179,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} quadros · decodificando`,
     aboutEta: (duration, frames) => `Cerca de ${duration} · ${frames} quadros`,
     etaTotal: (duration) => `${duration} no total`,
+    resyncing: "Os dados recuperados não passaram na verificação. Ressincronizando e continuando…",
+    resyncRestartSender: "Se isso continuar, reinicie o remetente.",
     transferFailedShort: "Falha na transferência",
     transferFailedDetail:
       "Nada aproveitável saiu desse fluxo. Reinicie o remetente e escaneie de novo — " +

--- a/shared/i18n/locales/ru.ts
+++ b/shared/i18n/locales/ru.ts
@@ -186,6 +186,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `кадров: ${frames} · декодирование`,
     aboutEta: (duration, frames) => `Около ${duration} · кадров: ${frames}`,
     etaTotal: (duration) => `всего ${duration}`,
+    resyncing: "Восстановленные данные не прошли проверку. Повторная синхронизация…",
+    resyncRestartSender: "Если это повторяется, перезапустите отправителя.",
     transferFailedShort: "Передача не удалась",
     transferFailedDetail:
       "Из этого потока не удалось извлечь ничего пригодного. Перезапустите отправителя " +

--- a/shared/i18n/locales/zh-hans.ts
+++ b/shared/i18n/locales/zh-hans.ts
@@ -174,6 +174,8 @@ export const messages: Messages = {
     framesDecoding: (frames) => `${frames} 帧 · 解码中`,
     aboutEta: (duration, frames) => `约 ${duration} · ${frames} 帧`,
     etaTotal: (duration) => `共 ${duration}`,
+    resyncing: "恢复的数据未通过验证。正在重新同步并继续接收…",
+    resyncRestartSender: "如果持续发生，请重启发送方。",
     transferFailedShort: "传输失败",
     transferFailedDetail:
       "这条数据流没有恢复出任何可用内容。请重启发送方，再扫一次——" +

--- a/shared/i18n/messages.ts
+++ b/shared/i18n/messages.ts
@@ -202,6 +202,9 @@ export interface Messages {
     framesDecoding: (frames: string) => string;
     aboutEta: (duration: string, frames: string) => string;
     etaTotal: (duration: string) => string; // "12s total"
+    /** A completed fountain assembly failed verification; capture continues. */
+    resyncing: string;
+    resyncRestartSender: string;
     transferFailedShort: string; // eta line + failure heading
     transferFailedDetail: string;
     tryAgain: string;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -147,8 +147,14 @@ export interface OpticalFile {
 }
 
 async function digest(bytes: Uint8Array): Promise<Uint8Array> {
-  const stableBytes = Uint8Array.from(bytes);
-  return new Uint8Array(await crypto.subtle.digest("SHA-256", stableBytes));
+  // Browser-created Uint8Arrays already own an ArrayBuffer. Pass the view
+  // directly so verifying a 64 MB transfer does not first allocate and copy a
+  // second 64 MB buffer. SharedArrayBuffer-backed views keep the safe copy.
+  const input =
+    bytes.buffer instanceof ArrayBuffer
+      ? (bytes as Uint8Array<ArrayBuffer>)
+      : Uint8Array.from(bytes);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", input));
 }
 
 async function gzipAsync(bytes: Uint8Array): Promise<Uint8Array> {

--- a/shared/receiver-session.ts
+++ b/shared/receiver-session.ts
@@ -1,0 +1,78 @@
+import { fnv1a, unpackFile, verifyFile, type OpticalFile } from "./protocol";
+
+export type CompletionFailureReason =
+  | "payload-checksum"
+  | "container-invalid"
+  | "file-digest";
+
+export type CompletionVerification =
+  | { ok: true; file: OpticalFile }
+  | { ok: false; reason: CompletionFailureReason };
+
+/** Verify recovered bytes without changing receiver state or tearing down I/O. */
+export async function verifyCompletedPayload(
+  payload: Uint8Array,
+  expectedFnv: number,
+): Promise<CompletionVerification> {
+  if (fnv1a(payload) !== expectedFnv) return { ok: false, reason: "payload-checksum" };
+
+  let file: OpticalFile;
+  try {
+    file = await unpackFile(payload);
+  } catch {
+    return { ok: false, reason: "container-invalid" };
+  }
+
+  try {
+    return (await verifyFile(file))
+      ? { ok: true, file }
+      : { ok: false, reason: "file-digest" };
+  } catch {
+    return { ok: false, reason: "file-digest" };
+  }
+}
+
+/**
+ * Completion verification is asynchronous. One stream may have only one
+ * verification in flight, while a newly detected stream must not wait for an
+ * obsolete stream's digest to finish.
+ */
+export class CompletionClaims {
+  private readonly active = new Set<string>();
+
+  claim(identity: string): boolean {
+    if (this.active.has(identity)) return false;
+    this.active.add(identity);
+    return true;
+  }
+
+  release(identity: string): void {
+    this.active.delete(identity);
+  }
+}
+
+/** Bounded duplicate suppression for worker replies that decode the same QR. */
+export class RecentFrameFilter {
+  private readonly keys = new Set<string>();
+  private readonly order: string[] = [];
+
+  constructor(private readonly limit = 256) {
+    if (!Number.isInteger(limit) || limit < 1) throw new RangeError("limit must be positive");
+  }
+
+  isDuplicate(identity: string, seq: number): boolean {
+    const key = `${identity}\u0000${seq}`;
+    if (this.keys.has(key)) return true;
+    this.keys.add(key);
+    this.order.push(key);
+    if (this.order.length > this.limit) {
+      this.keys.delete(this.order.shift()!);
+    }
+    return false;
+  }
+
+  clear(): void {
+    this.keys.clear();
+    this.order.length = 0;
+  }
+}

--- a/tests/decode-policy.test.ts
+++ b/tests/decode-policy.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MAX_DOWNSCALE,
+  TARGET_PX_PER_MODULE,
+  cropDownscale,
+  downscaleForPxPerModule,
+  downsizedDimension,
+  fullScanDownscale,
+  tryHarderForFullScan,
+} from "../shared/decode-policy.ts";
+
+test("the target keeps about 5 px per module at scale 1", () => {
+  assert.equal(TARGET_PX_PER_MODULE, 5);
+  // Just under the target, no downscale at all.
+  assert.equal(downscaleForPxPerModule(1), 1);
+  assert.equal(downscaleForPxPerModule(4.9), 1);
+  assert.equal(downscaleForPxPerModule(5), 1);
+  // 10 px/module: the code is twice as dense as it needs to be — halve it.
+  assert.equal(downscaleForPxPerModule(9.9), 1);
+  assert.equal(downscaleForPxPerModule(10), 2);
+  assert.equal(downscaleForPxPerModule(14), 2);
+  // 15 px/module: a third of the pixels.
+  assert.equal(downscaleForPxPerModule(15), 3);
+  assert.equal(downscaleForPxPerModule(19.99), 3);
+  // 20+ px/module: capped at the safety ceiling.
+  assert.equal(downscaleForPxPerModule(20), 4);
+  assert.equal(downscaleForPxPerModule(100), MAX_DOWNSCALE);
+  // A non-finite density is a broken measurement, not a license to shrink —
+  // the safe answer is "leave it alone".
+  assert.equal(downscaleForPxPerModule(Infinity), 1);
+});
+
+test("unmeasurable densities never downscale", () => {
+  // No yardstick, no risk: a sighting region without a measured px/module must
+  // always decode at full resolution.
+  assert.equal(cropDownscale(0), 1);
+  assert.equal(cropDownscale(-5), 1);
+  assert.equal(cropDownscale(NaN), 1);
+  assert.equal(fullScanDownscale(0), 1);
+});
+
+test("a full scan only shrinks when every live code can afford it", () => {
+  // The densest code sets the floor: 10 px/module on a 2-code grid means the
+  // smallest live code is still 2× denser than needed, so the scan halves.
+  assert.equal(fullScanDownscale(10), 2);
+  assert.equal(fullScanDownscale(4), 1, "a dense code must never be shrunk away");
+});
+
+test("tryHarder is reserved for acquisition and degraded rescans", () => {
+  // Cold: nothing decoded yet — every extra detector pass helps find the code.
+  assert.equal(tryHarderForFullScan(0, 0), true);
+  assert.equal(tryHarderForFullScan(0, 4), true);
+  // Degraded: a code went missing — the scan must reacquire it hard.
+  assert.equal(tryHarderForFullScan(1, 4), true);
+  assert.equal(tryHarderForFullScan(3, 4), true);
+  // Healthy: every expected code is live — the scan is background
+  // re-verification, and crops hold the lock, so it can relax.
+  assert.equal(tryHarderForFullScan(4, 4), false);
+  assert.equal(tryHarderForFullScan(5, 4), false);
+});
+
+test("a downscaled dimension never goes below 1", () => {
+  assert.equal(downsizedDimension(100, 4), 25);
+  assert.equal(downsizedDimension(32, 4), 8);
+  assert.equal(downsizedDimension(31, 4), 7);
+  assert.equal(downsizedDimension(100, 1), 100);
+  assert.equal(downsizedDimension(4, 4), 1);
+});

--- a/tests/fountain.test.ts
+++ b/tests/fountain.test.ts
@@ -402,3 +402,24 @@ test("an incomplete decoder assembles nothing", () => {
   assert.equal(decoder.isComplete, false);
   assert.equal(decoder.assemble(), null);
 });
+
+test("a completed decoder stops solving — the receiver replaces it on resync", () => {
+  // Pins the behavior the receiver's failed-verification path depends on:
+  // LTDecoder is spent once complete, so the receiver must replace the
+  // instance rather than feed it more frames.
+  const blockLen = 64;
+  const payload = testPayload(5 * blockLen - 7);
+  const encoder = new LTEncoder(payload, blockLen, 9);
+  const decoder = new LTDecoder(encoder.k, blockLen, 9, payload.length);
+  for (let seq = 0; seq < encoder.k; seq++) decoder.addFrame(seq, encoder.encode(seq));
+  assert.ok(decoder.isComplete);
+  assert.equal(decoder.solvedCount, encoder.k);
+  const framesNew = decoder.framesNew;
+
+  // A further frame is counted as an arrival but changes nothing else: the
+  // instance is spent. Re-swept blocks would never re-solve it.
+  decoder.addFrame(encoder.k * 3 + 7, encoder.encode(encoder.k * 3 + 7));
+  assert.equal(decoder.framesNew, framesNew + 1, "still counted as a new arrival");
+  assert.equal(decoder.solvedCount, encoder.k, "no new solving");
+  assert.deepEqual(decoder.assemble(), payload, "assembly is unaffected");
+});

--- a/tests/receiver-session.test.ts
+++ b/tests/receiver-session.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LTDecoder, LTEncoder } from "../shared/fountain.ts";
+import { fnv1a, packFile } from "../shared/protocol.ts";
+import {
+  CompletionClaims,
+  RecentFrameFilter,
+  verifyCompletedPayload,
+} from "../shared/receiver-session.ts";
+
+test("completion verification classifies each recoverable failure", async () => {
+  const packed = await packFile(
+    "payload.bin",
+    "application/octet-stream",
+    new Uint8Array([1, 2, 3, 4]),
+  );
+
+  assert.deepEqual(await verifyCompletedPayload(packed.container, fnv1a(packed.container) ^ 1), {
+    ok: false,
+    reason: "payload-checksum",
+  });
+
+  const malformed = packed.container.slice();
+  malformed[0] ^= 0xff;
+  assert.deepEqual(await verifyCompletedPayload(malformed, fnv1a(malformed)), {
+    ok: false,
+    reason: "container-invalid",
+  });
+
+  const badDigest = packed.container.slice();
+  badDigest[17] ^= 0xff;
+  assert.deepEqual(await verifyCompletedPayload(badDigest, fnv1a(badDigest)), {
+    ok: false,
+    reason: "file-digest",
+  });
+});
+
+test("a failed assembly can be recovered by a fresh decoder on the same stream", async () => {
+  const packed = await packFile(
+    "payload.bin",
+    "application/octet-stream",
+    new Uint8Array(2_000).map((_, i) => (i * 37) & 0xff),
+  );
+  const sessionId = 42;
+  const encoder = new LTEncoder(packed.container, 256, sessionId);
+
+  const poisoned = new LTDecoder(encoder.k, encoder.blockLen, sessionId, packed.container.length);
+  for (let seq = 0; seq < encoder.k; seq++) {
+    const block = encoder.encode(seq);
+    if (seq === 0) block[0] ^= 0xff;
+    poisoned.addFrame(seq, block);
+  }
+  assert.ok(poisoned.isComplete);
+  const first = await verifyCompletedPayload(poisoned.assemble()!, fnv1a(packed.container));
+  assert.deepEqual(first, { ok: false, reason: "payload-checksum" });
+
+  const replacement = new LTDecoder(
+    encoder.k,
+    encoder.blockLen,
+    sessionId,
+    packed.container.length,
+  );
+  for (let seq = 0; seq < encoder.k; seq++) replacement.addFrame(seq, encoder.encode(seq));
+  const second = await verifyCompletedPayload(replacement.assemble()!, fnv1a(packed.container));
+  assert.equal(second.ok, true);
+});
+
+test("completion claims suppress same-stream races without blocking a new stream", () => {
+  const claims = new CompletionClaims();
+  assert.equal(claims.claim("stream-a"), true);
+  assert.equal(claims.claim("stream-a"), false);
+  assert.equal(claims.claim("stream-b"), true);
+  claims.release("stream-a");
+  assert.equal(claims.claim("stream-a"), true);
+});
+
+test("recent-frame filtering suppresses duplicates and stays bounded", () => {
+  const frames = new RecentFrameFilter(2);
+  assert.equal(frames.isDuplicate("stream", 1), false);
+  assert.equal(frames.isDuplicate("stream", 1), true);
+  assert.equal(frames.isDuplicate("stream", 2), false);
+  assert.equal(frames.isDuplicate("stream", 3), false);
+  assert.equal(frames.isDuplicate("stream", 1), false, "old entries should be evicted");
+  frames.clear();
+  assert.equal(frames.isDuplicate("stream", 3), false);
+});


### PR DESCRIPTION
## Summary

- verify FNV, container structure, and SHA-256 before tearing down capture; replace a spent fountain decoder and keep receiving on failure
- suppress recent duplicate worker replies, preserve run-wide metrics across resyncs, and report machine-readable resync reasons
- downscale dense crops/full scans and reserve tryHarder for acquisition or degraded tracking
- offer capability-gated 90/120 fps capture settings and avoid copying large ArrayBuffer-backed inputs before WebCrypto hashing
- add localized resync guidance, focused unit/integration coverage, and a repository quality gate

## Compatibility

This ports the receiver work onto wire v3 and retains current upstream stream identity, version/flag verdicts, camera switching, localization, and auto-show privacy behavior. There is no wire-format change.

## Validation

- workspace-quality-gate (124 tests, hosted build, both standalone builds, diff check)
- gitleaks directory scan: no leaks
- served receive chunk: 22.57 KB, below the existing 24 KB CI ceiling

## Follow-up

The non-English resync strings should receive native-speaker review. # npm audit report

nanoid  <3.3.17
Severity: high
nanoid: custom generators can loop indefinitely when size is zero - https://github.com/advisories/GHSA-2v37-7h3g-55p8
fix available via `npm audit fix`
node_modules/nanoid

1 high severity vulnerability

To address all issues, run:
  npm audit fix also reports the existing upstream nanoid advisory; that is intentionally left for a separate dependency-only change.