### PR TITLE
Generate sender QR frames in workers

### DIFF
--- a/.agents/quality-gate
+++ b/.agents/quality-gate
@@ -1,0 +1,3 @@
+npm test
+npm run build:all
+git diff --check

--- a/build/use-inline-variants.ts
+++ b/build/use-inline-variants.ts
@@ -15,6 +15,7 @@ export function useInlineVariants(rootDir: string): Plugin {
     ["./worker-factory", "receive/worker-factory.inline.ts"],
     ["./wasm-url", "receive/wasm-url.inline.ts"],
     ["./support", "receive/support.inline.ts"],
+    ["./qr-worker-factory", "send/qr-worker-factory.inline.ts"],
     // A single file speaks every language; the dynamic per-locale imports
     // would also land after the entry's top-level await once inlined (TDZ).
     ["./loaders", "shared/i18n/loaders.inline.ts"],

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -19,6 +19,7 @@ Three pages, one shared core, a handful of single-purpose build plugins. No fram
 - `display.ts` — QR display-size fitting against the viewport.
 - `platform.ts` — `isIOS`/`isAndroid` sniffs and camera capability probing (torch, continuous focus, max fps). Policy: probe wherever probeable; sniff only for unprobeable behavior.
 - `worker-pool.ts` — decode worker pool; busy workers drop frames, the fountain absorbs it.
+- `qr-pool.ts` — bounded sender encode-worker queue; results may finish out of order and are reordered by sequence before paint.
 - `no-signal.ts` — pure timing policy for the "Nothing happening?" hint (short first delay, longer after dismissal).
 - `progress.ts` — frames-collected progress estimation and fountain-overhead model.
 - `send-settings.ts` — canonical tx settings lists; the sender's dropdowns and the no-signal advice both render from it.

--- a/send/main.ts
+++ b/send/main.ts
@@ -12,9 +12,8 @@
 // - Error correction stays at L by default: the fountain layer already
 //   handles erasures, and a frame is either decoded whole or discarded.
 
-import QRCode from "qrcode";
 import { fitQrDisplaySize } from "../shared/display";
-import { gridDims, rasterizeQr } from "../shared/qr-raster";
+import { gridDims } from "../shared/qr-raster";
 import {
   fillRuntimeTokens,
   fmtInt,
@@ -46,11 +45,16 @@ import {
 import { statusLine } from "../shared/status-line";
 import { requestScreenWakeLock } from "../shared/wake-lock";
 import { wireShareDialog } from "../shared/share-dialog";
+import { QrGenPool, type QrGenError, type QrGenResult } from "../shared/qr-pool";
+import { createQrWorker } from "./qr-worker-factory";
 
 await initI18n();
 
 const MARGIN = 4; // quiet-zone modules
 const LOOKAHEAD = 3;
+// Two workers cover a 4-code grid at 60 fps with headroom while leaving the
+// phone's remaining cores free for layout, paint, and browser work.
+const QR_WORKERS = 2;
 
 // `npm run demo` (vite --mode demo). Locks the sender to the two bundled
 // payloads so the app can be left running in front of strangers without
@@ -103,6 +107,7 @@ let selectedFile: {
 } | null = null;
 let generation = 0; // bumped on every restart; stale loops see it and die
 let resizeDisplay: (() => void) | null = null;
+let streamQrPool: QrGenPool | null = null;
 
 const specsLine = statusLine(specs);
 const setStatus = specsLine.setStatus;
@@ -335,6 +340,8 @@ function scrollStageIntoView() {
 async function startStream(revealStage = false) {
   const gen = ++generation;
   resizeDisplay = null;
+  streamQrPool?.terminate();
+  streamQrPool = null;
   // Stale until this stream's first frame locks its version and refills them.
   showStreamPanels(false);
   if (!selectedFile) {
@@ -397,7 +404,11 @@ async function startStream(revealStage = false) {
   // the same dimensions), so a mid-stream resize repaints from here instead of
   // leaving blank cells until the stagger rotation reaches them again.
   const cells: (ImageData | null)[] = new Array<ImageData | null>(gridCodes).fill(null);
-  let nextSeq = 0;
+  const results = new Map<number, QrGenResult>();
+  let nextSeq = 0; // next completed result the paint queue may consume
+  let issuedSeq = 0; // next fountain frame handed to a worker
+  let generatorFailed = false;
+  const lookahead = LOOKAHEAD * gridCodes;
   stage.hidden = false;
 
   const sizeCanvas = () => {
@@ -460,89 +471,93 @@ async function startStream(revealStage = false) {
     ctx.drawImage(staging, 0, 0, canvas.width, canvas.height);
   };
 
-  const makeCode = (): ReturnType<typeof QRCode.create> => {
-    const bytes = packFrame({ ...header, seq: nextSeq }, encoder.encode(nextSeq));
-    nextSeq++;
-    // Every code carries the same byte length at the same ECC with the same
-    // pinned mask, so once the first one locks the version every later
-    // QRCode.create lands on identical geometry — required for tiling.
-    return QRCode.create([{ data: bytes, mode: "byte" } as unknown as QRCode.QRCodeSegment], {
-      errorCorrectionLevel: ecc,
-      version,
-      maskPattern: 4,
-    });
+  /** Lock geometry and expose stream metadata when the first ordered worker
+   * result arrives. Later results have the same byte length, ECC, and pinned
+   * mask, so they necessarily use the same version. */
+  const lockFirstFrame = (frame: QrGenResult) => {
+    version = frame.version;
+    modules = frame.size - 2 * MARGIN;
+    sizeCanvas();
+    resizeDisplay = sizeCanvas;
+    // Scroll only now: before sizeCanvas() the canvas is still 16×16, so the
+    // scroll target would be the wrong height.
+    if (revealStage) scrollStageIntoView();
+    // The stream's parameters live at the bottom of Transfer settings, next
+    // to the knobs that produced them; the status line stays for prose.
+    spec("spec-fps").textContent = msg.send.fpsValue(String(txFps), gridCodes);
+    spec("spec-frame").textContent = msg.send.frameBytesValue(String(frameBytes), gridCodes);
+    spec("spec-qr").textContent =
+      `V${version}${gridCodes > 1 ? ` ×${gridCodes}` : ""} · ECC ${ecc}`;
+    spec("spec-payload").textContent = `${name} · ${formatBytesL(fileSize)}`;
+    spec("spec-compression").textContent =
+      compression === "gzip"
+        ? msg.send.gzipTo(formatBytesL(transmittedSize))
+        : msg.send.compressionNone;
+    spec("spec-k").textContent = `K = ${encoder.k}`;
+    showStreamPanels(true);
+    // The tail of the status line is the door to the share dialog. Built by
+    // hand because setStatus is textContent-only — and the next setStatus
+    // wiping the button out is exactly right.
+    setStatus(msg.send.streaming(name));
+    const share = document.createElement("button");
+    share.type = "button";
+    share.className = "text-button";
+    share.textContent = msg.send.shareReceiverLink;
+    share.addEventListener("click", openShareDialog);
+    specs.append(share);
+    // npm run diagnostics: announce this stream's settings so the server
+    // log can pair them with the receiver's end-of-run report — the
+    // receiver only ever learns k and blockLen from the wire, never the
+    // knobs that produced them. Correlate the two by sessionId. The DEV
+    // guard is load-bearing: import.meta.env.DEV is statically false in
+    // every build, so no static site or standalone file ships this.
+    if (import.meta.env.DEV && import.meta.env.VITE_DIAGNOSTICS === "1") {
+      void fetch("/__diagnostics", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          role: "sender",
+          when: new Date().toISOString(),
+          sessionId,
+          payload: {
+            name,
+            fileBytes: fileSize,
+            containerBytes: payload.length,
+            transmittedBytes: transmittedSize,
+            compression,
+          },
+          settings: {
+            txFps,
+            frameBytes,
+            ecc,
+            gridCodes,
+            layout: `${gridCols}×${gridRows}`,
+            displayPx,
+          },
+          qr: { version, modules },
+          fountain: { k: encoder.k, blockLen },
+          ua: navigator.userAgent,
+        }),
+      }).catch(() => undefined);
+    }
   };
 
-  const makeCell = (): ImageData => {
-    const qr = makeCode();
-    if (version === undefined) {
-      version = qr.version;
-      modules = qr.modules.size;
-      sizeCanvas();
-      resizeDisplay = sizeCanvas;
-      // Scroll only now: before sizeCanvas() the canvas is still 16×16, so the
-      // scroll target would be the wrong height.
-      if (revealStage) scrollStageIntoView();
-      // The stream's parameters live at the bottom of Transfer settings, next
-      // to the knobs that produced them; the status line stays for prose.
-      spec("spec-fps").textContent = msg.send.fpsValue(String(txFps), gridCodes);
-      spec("spec-frame").textContent = msg.send.frameBytesValue(String(frameBytes), gridCodes);
-      spec("spec-qr").textContent =
-        `V${version}${gridCodes > 1 ? ` ×${gridCodes}` : ""} · ECC ${ecc}`;
-      spec("spec-payload").textContent = `${name} · ${formatBytesL(fileSize)}`;
-      spec("spec-compression").textContent =
-        compression === "gzip" ? msg.send.gzipTo(formatBytesL(transmittedSize)) : msg.send.compressionNone;
-      spec("spec-k").textContent = `K = ${encoder.k}`;
-      showStreamPanels(true);
-      // The tail of the status line is the door to the share dialog. Built by
-      // hand because setStatus is textContent-only — and the next setStatus
-      // wiping the button out is exactly right.
-      setStatus(msg.send.streaming(name));
-      const share = document.createElement("button");
-      share.type = "button";
-      share.className = "text-button";
-      share.textContent = msg.send.shareReceiverLink;
-      share.addEventListener("click", openShareDialog);
-      specs.append(share);
-      // npm run diagnostics: announce this stream's settings so the server
-      // log can pair them with the receiver's end-of-run report — the
-      // receiver only ever learns k and blockLen from the wire, never the
-      // knobs that produced them. Correlate the two by sessionId. The DEV
-      // guard is load-bearing: import.meta.env.DEV is statically false in
-      // every build, so no static site or standalone file ships this.
-      if (import.meta.env.DEV && import.meta.env.VITE_DIAGNOSTICS === "1") {
-        void fetch("/__diagnostics", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            role: "sender",
-            when: new Date().toISOString(),
-            sessionId,
-            payload: {
-              name,
-              fileBytes: fileSize,
-              containerBytes: payload.length,
-              transmittedBytes: transmittedSize,
-              compression,
-            },
-            settings: {
-              txFps,
-              frameBytes,
-              ecc,
-              gridCodes,
-              layout: `${gridCols}×${gridRows}`,
-              displayPx,
-            },
-            qr: { version, modules },
-            fountain: { k: encoder.k, blockLen },
-            ua: navigator.userAgent,
-          }),
-        }).catch(() => undefined);
-      }
-    }
-    const raster = rasterizeQr(qr.modules.size, qr.modules.data, MARGIN);
-    return new ImageData(new Uint8ClampedArray(raster.pixels.buffer), raster.size, raster.size);
+  const completeFrame = (frame: QrGenResult) => {
+    if (generatorFailed || gen !== generation) return;
+    results.set(frame.id, frame);
+    pump();
   };
+
+  const onQrError = (error: QrGenError) => {
+    if (generatorFailed || gen !== generation) return;
+    generatorFailed = true;
+    streamQrPool?.terminate();
+    streamQrPool = null;
+    showError(error.error);
+  };
+
+  const qrPool = new QrGenPool(QR_WORKERS, completeFrame, onQrError, createQrWorker);
+  streamQrPool = qrPool;
 
   /**
    * Refill the lookahead, generating at most `max` frames per call.
@@ -553,16 +568,21 @@ async function startStream(revealStage = false) {
    * one frame per tick keeps the amortisation that gave us: a rAF callback
    * never pays for more than the single frame it just consumed.
    */
-  let generatorFailed = false;
-  const lookahead = LOOKAHEAD * gridCodes;
   const pump = (max = lookahead) => {
     if (generatorFailed || gen !== generation) return;
-    try {
-      for (let n = 0; n < max && queue.length < lookahead; n++) queue.push(makeCell());
-    } catch (err) {
-      // e.g. frame bytes over capacity for the chosen ECC level
-      generatorFailed = true;
-      showError(err instanceof Error ? err.message : String(err));
+    // Workers may finish out of order; only contiguous sequence ids enter the
+    // paint queue, preserving the wire sequence and deterministic carousel.
+    for (let n = 0; n < max && queue.length < lookahead && results.has(nextSeq); n++) {
+      const frame = results.get(nextSeq)!;
+      results.delete(nextSeq);
+      if (version === undefined) lockFirstFrame(frame);
+      queue.push(new ImageData(new Uint8ClampedArray(frame.pixels.buffer), frame.size, frame.size));
+      nextSeq++;
+    }
+    while (issuedSeq < nextSeq + lookahead) {
+      const bytes = packFrame({ ...header, seq: issuedSeq }, encoder.encode(issuedSeq));
+      qrPool.submit({ id: issuedSeq, version, ecc, bytes });
+      issuedSeq++;
     }
   };
   pump();

--- a/send/qr-worker-factory.inline.ts
+++ b/send/qr-worker-factory.inline.ts
@@ -1,0 +1,8 @@
+// Standalone builds only. A module worker loaded from a file:// page is blocked
+// by the opaque origin, so the worker ships as a base64 blob URL, which file://
+// permits. Same trade-off as the receive side's worker-factory.inline.ts.
+import InlineQrWorker from "./qr-worker.ts?worker&inline";
+
+export function createQrWorker(): Worker {
+  return new InlineQrWorker();
+}

--- a/send/qr-worker-factory.ts
+++ b/send/qr-worker-factory.ts
@@ -1,0 +1,8 @@
+// Served builds: a module worker fetched by URL, matching the receive side's
+// worker-factory pattern.
+//
+// Standalone builds swap this file for qr-worker-factory.inline.ts at resolve
+// time (see vite.config.ts / build/use-inline-variants.ts).
+export function createQrWorker(): Worker {
+  return new Worker(new URL("./qr-worker.ts", import.meta.url), { type: "module" });
+}

--- a/send/qr-worker.ts
+++ b/send/qr-worker.ts
@@ -1,0 +1,47 @@
+// QR encode worker: QRCode.create (up to V40) + rasterizeQr run OFF the main
+// thread, so the sender's rAF paint loop never stalls on a phone. The module
+// raster comes back as a transferred pixel buffer; the main thread wraps it in
+// an ImageData at zero copy.
+//
+// The qrcode browser entry touches `document` only inside its canvas renderers,
+// which this worker never calls — importing it here is safe.
+
+import QRCode from "qrcode";
+import { rasterizeQr } from "../shared/qr-raster";
+
+const MARGIN = 4; // quiet-zone modules — must match send/main.ts
+
+interface EncodeRequest {
+  id: number;
+  /** Locked after the first frame; undefined lets the worker auto-select the
+   *  version (deterministic for a fixed byte length + ECC, so pre-lock frames
+   *  and post-lock frames still land on identical geometry). */
+  version?: number;
+  ecc: "L" | "M" | "Q" | "H";
+  bytes: Uint8Array;
+}
+
+const ctx = self as unknown as {
+  onmessage: ((e: MessageEvent) => void) | null;
+  postMessage(msg: unknown, transfer?: Transferable[]): void;
+};
+
+ctx.onmessage = (event: MessageEvent) => {
+  const { id, version, ecc, bytes } = event.data as EncodeRequest;
+  try {
+    const qr = QRCode.create([{ data: bytes, mode: "byte" } as unknown as QRCode.QRCodeSegment], {
+      errorCorrectionLevel: ecc,
+      version,
+      maskPattern: 4, // pinned — see the tuning notes in send/main.ts
+    });
+    const raster = rasterizeQr(qr.modules.size, qr.modules.data, MARGIN);
+    ctx.postMessage(
+      { id, version: qr.version, size: raster.size, pixels: raster.pixels },
+      [raster.pixels.buffer],
+    );
+  } catch (err) {
+    // e.g. frame bytes over capacity for the chosen ECC level — the main
+    // thread turns this into the same error it used to catch synchronously.
+    ctx.postMessage({ id, error: err instanceof Error ? err.message : String(err) });
+  }
+};

--- a/shared/qr-pool.ts
+++ b/shared/qr-pool.ts
@@ -1,0 +1,94 @@
+// Ordered pool of QR-encode workers for the sender. Unlike DecodeWorkerPool
+// (receive side), which is fire-and-drop, this pool hands every result back to
+// the caller keyed by request id, and the sender drains results strictly in
+// sequence order, so out-of-order completion is harmless. Bytes buffers are
+// transferred to the workers at zero copy; the returned raster pixel buffers
+// are transferred back the same way.
+
+export interface QrGenWorker {
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  terminate(): void;
+}
+
+export type QrEcc = "L" | "M" | "Q" | "H";
+
+export interface QrGenRequest {
+  id: number;
+  /** Locked after the first frame; undefined lets the worker auto-select the
+   *  version, which is deterministic for a fixed byte length + ECC. */
+  version?: number;
+  ecc: QrEcc;
+  bytes: Uint8Array;
+}
+
+export interface QrGenResult {
+  id: number;
+  version: number;
+  size: number;
+  pixels: Uint32Array<ArrayBuffer>;
+}
+
+export interface QrGenError {
+  id: number;
+  error: string;
+}
+
+export class QrGenPool {
+  private readonly workers: QrGenWorker[] = [];
+  private readonly busy: boolean[] = [];
+  private readonly queue: QrGenRequest[] = [];
+  private terminated = false;
+
+  constructor(
+    count: number,
+    private readonly onResult: (result: QrGenResult) => void,
+    private readonly onError: (error: QrGenError) => void,
+    create: () => QrGenWorker,
+  ) {
+    for (let i = 0; i < count; i++) {
+      this.busy.push(false);
+      const worker = create();
+      worker.onmessage = (event: MessageEvent) => {
+        if (this.terminated) return;
+        this.busy[i] = false;
+        const message = event.data as QrGenResult | QrGenError;
+        if ("error" in message) this.onError(message);
+        else this.onResult(message);
+        this.dispatchNext();
+      };
+      this.workers.push(worker);
+    }
+  }
+
+  submit(request: QrGenRequest): void {
+    if (this.terminated) return;
+    this.queue.push(request);
+    this.dispatchNext();
+  }
+
+  /** Drops queued work and terminates the workers. Call when a stream ends or a
+   *  new stream takes over (a stale callback must not outlive its `generation`). */
+  terminate(): void {
+    if (this.terminated) return;
+    this.terminated = true;
+    this.queue.length = 0;
+    for (const worker of this.workers) {
+      worker.onmessage = null;
+      worker.terminate();
+    }
+    this.workers.length = 0;
+    this.busy.length = 0;
+  }
+
+  private dispatchNext(): void {
+    if (this.terminated) return;
+    while (this.queue.length > 0) {
+      const slot = this.busy.indexOf(false);
+      if (slot === -1) return; // all workers busy — wait for the next onmessage
+      const request = this.queue.shift()!;
+      this.busy[slot] = true;
+      this.workers[slot]!.postMessage(request, [request.bytes.buffer as ArrayBuffer]);
+    }
+  }
+}

--- a/tests/qr-pool.test.ts
+++ b/tests/qr-pool.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  QrGenPool,
+  type QrGenError,
+  type QrGenRequest,
+  type QrGenResult,
+  type QrGenWorker,
+} from "../shared/qr-pool.ts";
+
+class FakeWorker implements QrGenWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  readonly sent: QrGenRequest[] = [];
+  readonly transfers: Transferable[][] = [];
+  terminated = false;
+
+  postMessage(message: unknown, transfer: Transferable[] = []): void {
+    this.sent.push(message as QrGenRequest);
+    this.transfers.push(transfer);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  reply(message: QrGenResult | QrGenError): void {
+    this.onmessage?.({ data: message } as MessageEvent);
+  }
+}
+
+function request(id: number): QrGenRequest {
+  return { id, ecc: "L", bytes: new Uint8Array([id]) };
+}
+
+function result(id: number): QrGenResult {
+  return { id, version: 1, size: 29, pixels: new Uint32Array(29 * 29) };
+}
+
+function harness(count = 2) {
+  const workers: FakeWorker[] = [];
+  const results: QrGenResult[] = [];
+  const errors: QrGenError[] = [];
+  const pool = new QrGenPool(
+    count,
+    (value) => results.push(value),
+    (value) => errors.push(value),
+    () => {
+      const worker = new FakeWorker();
+      workers.push(worker);
+      return worker;
+    },
+  );
+  return { pool, workers, results, errors };
+}
+
+test("workers run concurrently and a freed slot takes queued work", () => {
+  const { pool, workers, results } = harness();
+  pool.submit(request(0));
+  pool.submit(request(1));
+  pool.submit(request(2));
+
+  assert.deepEqual(workers.map((worker) => worker.sent.map(({ id }) => id)), [[0], [1]]);
+  assert.equal(workers[0]!.transfers[0]![0], workers[0]!.sent[0]!.bytes.buffer);
+
+  workers[1]!.reply(result(1));
+  assert.deepEqual(results.map(({ id }) => id), [1], "pool completion order is intentionally raw");
+  assert.deepEqual(workers[1]!.sent.map(({ id }) => id), [1, 2]);
+});
+
+test("worker errors use the error callback and still free the slot", () => {
+  const { pool, workers, errors } = harness(1);
+  pool.submit(request(0));
+  pool.submit(request(1));
+  workers[0]!.reply({ id: 0, error: "too dense" });
+
+  assert.deepEqual(errors, [{ id: 0, error: "too dense" }]);
+  assert.deepEqual(workers[0]!.sent.map(({ id }) => id), [0, 1]);
+});
+
+test("termination drops queued work and prevents stale callbacks", () => {
+  const { pool, workers, results, errors } = harness(1);
+  pool.submit(request(0));
+  pool.submit(request(1));
+  const staleHandler = workers[0]!.onmessage;
+  pool.terminate();
+
+  assert.equal(workers[0]!.terminated, true);
+  assert.equal(workers[0]!.onmessage, null);
+  staleHandler?.({ data: result(0) } as MessageEvent);
+  pool.submit(request(2));
+  assert.deepEqual(results, []);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(workers[0]!.sent.map(({ id }) => id), [0]);
+});


### PR DESCRIPTION
## Summary

- move QRCode.create and rasterization into a two-worker sender pool
- transfer frame bytes and raster buffers without copies, then reorder out-of-order results by sequence before paint
- terminate stale workers and ignore queued callbacks when a stream stops or restarts
- add a blob-backed inline worker for file:// standalone senders
- cover pool concurrency, transfer lists, errors, queued work, and termination

## Compatibility

The fountain sequence, pinned QR mask, ECC, version locking, staggered grid paint, localized status text, and diagnostics payload are unchanged. This is a sender scheduling change only; there is no wire-format change.

## Validation

- workspace-quality-gate: tests, hosted build, both standalone builds, diff check
- gitleaks directory scan: no leaks
- served build emits a separate 26.34 KB QR worker
- standalone sender builds to one 253.83 KB HTML file with the worker embedded

This branch is independent of PR #42. Both add the same repository quality-gate file; whichever merges second can drop that already-landed file during rebase.