### PR TITLE
Record benchmark sender settings

### DIFF
--- a/.agents/quality-gate
+++ b/.agents/quality-gate
@@ -1,0 +1,3 @@
+npm test
+npm run build:all
+git diff --check

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ confidentiality — see [privacy](docs/user/privacy.md).
 
 One record run per device pair. Sustained is whole-transfer goodput;
 peak is the best ≥1 s window inside that same run. Every row links to
-the full diagnostics run report that produced it
+the full diagnostics run report that produced it; settings identify the
+sender configuration used by newly promoted records
 ([how these are measured](docs/technical/diagnostics.md)).
 
-| pair | sustained | peak | transfer | codes | devices | when | receipt |
-|---|---|---|---|---|---|---|---|
-| desktop → phone | **418.5 KB/s** | **601.5 KB/s** | 1.0 MB in 2.5 s | 4 | Odyssey G9 49″ → iPhone 17 Pro Max | 2026-08-09 (v0.4.0) | [run](benchmarks/runs/2026-08-09T04-12-41-run.json) |
-| phone → phone | **199.2 KB/s** | **340.8 KB/s** | 1.0 MB in 5.1 s | 2 | iPhone 17 Pro Max → iPhone 17 Pro Max | 2026-08-09 (v0.4.0) | [run](benchmarks/runs/2026-08-09T04-49-39-run.json) |
+| pair | sustained | peak | transfer | codes | settings | devices | when | receipt |
+|---|---|---|---|---|---|---|---|---|
+| desktop → phone | **418.5 KB/s** | **601.5 KB/s** | 1.0 MB in 2.5 s | 4 | legacy record | Odyssey G9 49″ → iPhone 17 Pro Max | 2026-08-09 (v0.4.0) | [run](benchmarks/runs/2026-08-09T04-12-41-run.json) |
+| phone → phone | **199.2 KB/s** | **340.8 KB/s** | 1.0 MB in 5.1 s | 2 | legacy record | iPhone 17 Pro Max → iPhone 17 Pro Max | 2026-08-09 (v0.4.0) | [run](benchmarks/runs/2026-08-09T04-49-39-run.json) |
 <!-- benchmarks:end -->
 
 ## Documentation

--- a/build/benchmark-settings.ts
+++ b/build/benchmark-settings.ts
@@ -1,0 +1,40 @@
+export interface SenderSettings {
+  txFps: number;
+  frameBytes: number;
+  ecc: "L" | "M" | "Q" | "H";
+  gridCodes: number;
+  layout: string;
+  displayPx?: number;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+/** Captured diagnostics are local JSON, but still untyped input. Invalid or
+ * partial sender announcements must never become benchmark provenance. */
+export function parseSenderSettings(value: unknown): SenderSettings | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as UnknownRecord;
+  const { txFps, frameBytes, ecc, gridCodes, layout, displayPx } = raw;
+  if (typeof txFps !== "number" || !Number.isFinite(txFps) || txFps <= 0) return undefined;
+  if (typeof frameBytes !== "number" || !Number.isInteger(frameBytes) || frameBytes <= 0)
+    return undefined;
+  if (ecc !== "L" && ecc !== "M" && ecc !== "Q" && ecc !== "H") return undefined;
+  if (typeof gridCodes !== "number" || !Number.isInteger(gridCodes) || gridCodes <= 0)
+    return undefined;
+  if (typeof layout !== "string" || !/^\d+×\d+$/.test(layout)) return undefined;
+  if (
+    displayPx !== undefined &&
+    (typeof displayPx !== "number" || !Number.isFinite(displayPx) || displayPx <= 0)
+  )
+    return undefined;
+  return { txFps, frameBytes, ecc, gridCodes, layout, ...(displayPx ? { displayPx } : {}) };
+}
+
+export function formatSenderSettings(settings: SenderSettings): string {
+  const codes = `${settings.gridCodes} ${settings.gridCodes === 1 ? "code" : "codes"}`;
+  const display = settings.displayPx ? ` · ${settings.displayPx} px` : "";
+  return (
+    `${settings.txFps} fps · ${settings.frameBytes} B · ECC-${settings.ecc}` +
+    ` · ${codes} (${settings.layout})${display}`
+  );
+}

--- a/build/benchmarks.ts
+++ b/build/benchmarks.ts
@@ -21,6 +21,11 @@ import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFi
 import { resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { fileURLToPath } from "node:url";
+import {
+  formatSenderSettings,
+  parseSenderSettings,
+  type SenderSettings,
+} from "./benchmark-settings";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const RECORDS_PATH = resolve(ROOT, "benchmarks/records.json");
@@ -50,6 +55,9 @@ interface RecordEntry {
   version: string | null; // app version stamped into the run by the endpoint
   runFile: string; // repo-relative receipt path
   badge: string; // preformatted for the shields.io dynamic-JSON badge
+  /** Sender announcement paired by session id. Optional only for records
+   * created before provenance capture was added. New promotions require it. */
+  settings?: SenderSettings;
 }
 
 interface CanonicalPayload {
@@ -207,9 +215,14 @@ interface CapturedRun {
 
 /** Load every captured report; pair receiver runs with sender announcements
  *  by sessionId for the device label's sending half. */
-function loadCaptured(paths: string[]): { receivers: CapturedRun[]; senderUa: Map<unknown, unknown> } {
+function loadCaptured(paths: string[]): {
+  receivers: CapturedRun[];
+  senderUa: Map<unknown, unknown>;
+  senderSettings: Map<unknown, SenderSettings>;
+} {
   const receivers: CapturedRun[] = [];
   const senderUa = new Map<unknown, unknown>();
+  const senderSettings = new Map<unknown, SenderSettings>();
   for (const path of paths) {
     let report: Report;
     try {
@@ -218,9 +231,13 @@ function loadCaptured(paths: string[]): { receivers: CapturedRun[]; senderUa: Ma
       continue; // half-written or foreign file — not a candidate
     }
     if (report.role === "receiver") receivers.push({ path, report });
-    else if (report.role === "sender" && report.settings) senderUa.set(report.sessionId, report.ua);
+    else if (report.role === "sender" && report.settings) {
+      senderUa.set(report.sessionId, report.ua);
+      const settings = parseSenderSettings(report.settings);
+      if (settings) senderSettings.set(report.sessionId, settings);
+    }
   }
-  return { receivers, senderUa };
+  return { receivers, senderUa, senderSettings };
 }
 
 async function promote(explicitPath?: string): Promise<void> {
@@ -241,24 +258,25 @@ async function promote(explicitPath?: string): Promise<void> {
     .filter((e) => e.isFile() && e.name.endsWith(".json"))
     .map((e) => resolve(CAPTURE_DIR, e.name))
     .sort();
-  const { receivers, senderUa } = loadCaptured(
+  const { receivers, senderUa, senderSettings } = loadCaptured(
     explicitPath ? [...capturedPaths, resolve(explicitPath)] : capturedPaths,
   );
   const pool = explicitPath
     ? receivers.filter((r) => r.path === resolve(explicitPath))
     : receivers;
 
-  const eligible = pool.filter(
+  const successful = pool.filter(
     (r) => r.report.ok === true && r.report.payloadSha256 === canonical.sha256,
   );
+  const eligible = successful.filter((r) => senderSettings.has(r.report.sessionId));
   console.log(
-    `${pool.length} receiver run(s) scanned, ${eligible.length} eligible ` +
-      "(successful + canonical payload)",
+    `${pool.length} receiver run(s) scanned, ${successful.length} successful canonical, ` +
+      `${eligible.length} with paired sender settings`,
   );
   if (eligible.length === 0)
     throw new Error(
-      "no eligible runs — record runs must complete successfully and transfer " +
-        `the canonical ${canonical.file} (npm run benchmark)`,
+      "no eligible runs — record runs need a successful canonical receiver report " +
+        "and its paired sender settings announcement from the same diagnostics session",
     );
 
   // Devices resolve first (registry list, remembered per UA) because the
@@ -321,6 +339,7 @@ async function promote(explicitPath?: string): Promise<void> {
       version: typeof meta.appVersion === "string" ? meta.appVersion : null,
       runFile: `benchmarks/runs/${stamp.slice(0, 19).replace(/:/g, "-")}-run.json`,
       badge: `${j.sustainedKBs} KB/s`,
+      settings: senderSettings.get(report.sessionId)!,
     };
   };
 
@@ -347,6 +366,7 @@ async function promote(explicitPath?: string): Promise<void> {
       `${entry.category} record: ${entry.sustainedKBs} KB/s sustained` +
         `${entry.peakKBs ? ` / ${entry.peakKBs} peak` : ""} (${entry.devices}, ${entry.date})`,
     );
+    console.log(`  settings: ${formatSenderSettings(entry.settings!)}`);
   }
   refreshBest(records);
   writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + "\n");
@@ -369,7 +389,8 @@ function tableRow(e: RecordEntry): string {
   const mb = (e.payloadBytes / 1024 / 1024).toFixed(1);
   const when = e.version ? `${e.date} (v${e.version})` : e.date;
   const peak = e.peakKBs ? `**${e.peakKBs} KB/s**` : "—";
-  return `| ${e.category} | **${e.sustainedKBs} KB/s** | ${peak} | ${mb} MB in ${e.seconds.toFixed(1)} s | ${e.codes} | ${e.devices} | ${when} | [run](${e.runFile}) |`;
+  const settings = e.settings ? formatSenderSettings(e.settings) : "legacy record";
+  return `| ${e.category} | **${e.sustainedKBs} KB/s** | ${peak} | ${mb} MB in ${e.seconds.toFixed(1)} s | ${e.codes} | ${settings} | ${e.devices} | ${when} | [run](${e.runFile}) |`;
 }
 
 function renderReadme(records: Records): void {
@@ -385,11 +406,12 @@ function renderReadme(records: Records): void {
     lines.push(
       "One record run per device pair. Sustained is whole-transfer goodput;",
       "peak is the best ≥1 s window inside that same run. Every row links to",
-      "the full diagnostics run report that produced it",
+      "the full diagnostics run report that produced it; settings identify the",
+      "sender configuration used by newly promoted records",
       "([how these are measured](docs/technical/diagnostics.md)).",
       "",
-      "| pair | sustained | peak | transfer | codes | devices | when | receipt |",
-      "|---|---|---|---|---|---|---|---|",
+      "| pair | sustained | peak | transfer | codes | settings | devices | when | receipt |",
+      "|---|---|---|---|---|---|---|---|---|",
       ...entries.sort((a, b) => b.sustainedKBs - a.sustainedKBs).map(tableRow),
     );
   }

--- a/docs/technical/diagnostics.md
+++ b/docs/technical/diagnostics.md
@@ -93,8 +93,9 @@ npm run benchmark    # dev server, capture on, sender locked to the payload
 
 Benchmark mode presets the sender to 4 codes (2×2); the sender's stream
 announcement records the actual settings, and the promoted record carries
-the receiver's observed code count — a record always says how many codes
-it was set with.
+the validated sender settings (bytes/frame, tx fps, ECC, layout) alongside the
+receiver's observed code count. New records without a paired sender
+announcement are rejected; older records remain readable as legacy entries.
 
 Run the transfer as many times as you like; every report the rig receives
 is stamped (`_meta`: app version, receipt time) and saved to the gitignored

--- a/tests/benchmark-settings.test.ts
+++ b/tests/benchmark-settings.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatSenderSettings,
+  parseSenderSettings,
+} from "../build/benchmark-settings.ts";
+
+const valid = {
+  txFps: 24,
+  frameBytes: 1465,
+  ecc: "L",
+  gridCodes: 4,
+  layout: "2×2",
+  displayPx: 900,
+} as const;
+
+test("complete sender diagnostics become benchmark provenance", () => {
+  assert.deepEqual(parseSenderSettings(valid), valid);
+  assert.equal(
+    formatSenderSettings(valid),
+    "24 fps · 1465 B · ECC-L · 4 codes (2×2) · 900 px",
+  );
+});
+
+test("legacy and malformed announcements are not promoted as provenance", () => {
+  for (const value of [
+    undefined,
+    {},
+    { ...valid, txFps: 0 },
+    { ...valid, frameBytes: 1.5 },
+    { ...valid, ecc: "Z" },
+    { ...valid, gridCodes: 0 },
+    { ...valid, layout: "2x2" },
+    { ...valid, displayPx: Number.NaN },
+  ]) {
+    assert.equal(parseSenderSettings(value), undefined, JSON.stringify(value));
+  }
+});
+
+test("single-code settings use singular provenance wording", () => {
+  const parsed = parseSenderSettings({ ...valid, gridCodes: 1, layout: "1×1" });
+  assert.ok(parsed);
+  assert.equal(
+    formatSenderSettings(parsed),
+    "24 fps · 1465 B · ECC-L · 1 code (1×1) · 900 px",
+  );
+});


### PR DESCRIPTION
## Summary

- validate and persist the sender's tx fps, bytes/frame, ECC, code count, layout, and display size with promoted benchmark records
- require a paired sender announcement for every new record instead of promoting unprovenanced receiver-only runs
- keep pre-provenance records readable and label them as legacy in generated README output
- render the winning sender configuration in the benchmark table and promotion log
- add parser/formatting tests for malformed, single-code, and multi-code settings

## Why

The receiver only sees fountain parameters, not the sender knobs that produced them. Without the paired sender report, a speed record cannot explain which configuration won or support evidence-based defaults.

## Validation

- workspace-quality-gate: tests, hosted build, both standalone builds, diff check
- npm run benchmark:readme is idempotent after regeneration
- gitleaks directory scan: no leaks

This branch is independent of PRs #42 and #43. The repeated quality-gate addition can be dropped on rebase after whichever PR lands first.