### PR TITLE
Write solved receiver blocks to their final offsets immediately

### DIFF
--- a/receive/main.ts
+++ b/receive/main.ts
@@ -15,6 +15,8 @@ import { LTDecoder } from "../shared/fountain";
 import {
   estimateTransferProgress,
   expectedFountainOverhead,
+  markRecoveredRange,
+  recoveredFraction,
 } from "../shared/progress";
 import {
   fmtInt,
@@ -121,6 +123,7 @@ const NO_SIGNAL_DISMISSED_MS = 15_000;
 // updateStats() are derived from this, so the window and the divisor can't
 // drift apart.
 const STATS_WINDOW_MS = 2000;
+const PROGRESS_COVERAGE_BINS = 160;
 
 let stream: MediaStream | null = null;
 let decoder: LTDecoder | null = null;
@@ -132,6 +135,12 @@ let captureGen = 0;
 let done = false;
 let settingsWired = false;
 let statsTimer: ReturnType<typeof setInterval> | undefined;
+let progressSolvedBlocks = 0;
+let progressTotalBlocks = 0;
+let progressTotalBytes = 0;
+let progressRecoveredBytes = 0;
+let progressEtaText = msg.receive.estimatingTime;
+let progressCoverage = new Float32Array(PROGRESS_COVERAGE_BINS);
 
 const noSignal = new NoSignalHintTimer(NO_SIGNAL_FIRST_MS, NO_SIGNAL_DISMISSED_MS);
 const pool = new DecodeWorkerPool(
@@ -429,6 +438,64 @@ noSignalDialog.addEventListener("close", dismissNoSignal);
 function dismissNoSignal() {
   noSignalToast.hidden = true;
   noSignal.dismiss(performance.now());
+}
+
+function progressPercentLabel(percent: number): string {
+  return percent < 10 ? fmtNumber(percent, 1, 1) : fmtNumber(percent, 0);
+}
+
+function coverageColor(alpha: number): string {
+  if (alpha <= 0.001) return "transparent";
+  if (alpha >= 0.999) return "var(--accent)";
+  return `rgba(var(--accent-rgb), ${alpha.toFixed(3)})`;
+}
+
+function progressFillStyle(): string {
+  if (progressRecoveredBytes <= 0) return "transparent";
+  const stops: string[] = [];
+  let runStart = 0;
+  let runColor = coverageColor(progressCoverage[0] ?? 0);
+  for (let i = 1; i <= progressCoverage.length; i++) {
+    const color = i < progressCoverage.length ? coverageColor(progressCoverage[i] ?? 0) : "";
+    if (color === runColor) continue;
+    const start = ((runStart * 100) / progressCoverage.length).toFixed(3);
+    const end = ((i * 100) / progressCoverage.length).toFixed(3);
+    stops.push(`${runColor} ${start}%`, `${runColor} ${end}%`);
+    runStart = i;
+    runColor = color;
+  }
+  return `linear-gradient(90deg, ${stops.join(", ")})`;
+}
+
+function renderProgressUi(percent: number) {
+  const clamped = Math.max(0, Math.min(100, percent));
+  bar.style.width = "100%";
+  bar.style.setProperty("--progress-fill", progressFillStyle());
+  progressEl.setAttribute("aria-valuenow", String(Math.floor(clamped)));
+  progressLabel.textContent = msg.receive.progressBlocks(
+    progressPercentLabel(clamped),
+    fmtInt(progressSolvedBlocks),
+    fmtInt(progressTotalBlocks),
+  );
+  etaLabel.textContent = progressEtaText;
+}
+
+function resetTransferProgressUi(totalBlocks: number) {
+  progressSolvedBlocks = 0;
+  progressTotalBlocks = totalBlocks;
+  progressTotalBytes = 0;
+  progressRecoveredBytes = 0;
+  progressEtaText = msg.receive.estimatingTime;
+  progressCoverage = new Float32Array(PROGRESS_COVERAGE_BINS);
+  bar.classList.remove("error");
+  renderProgressUi(0);
+}
+
+function finishTransferProgressUi(percent: number, etaText: string) {
+  progressEtaText = etaText;
+  progressCoverage.fill(1);
+  progressRecoveredBytes = progressTotalBytes;
+  renderProgressUi(percent);
 }
 
 /** By the time a transfer ends the camera, worker pool and stats timer are all
@@ -933,6 +1000,13 @@ function onDecoded(bytes: Uint8Array, box?: SymbolBox, info?: SymbolInfo) {
       header.totalLen,
       (index, bytes) => {
         receivedContainer?.set(bytes, index * header.blockLen);
+        progressRecoveredBytes += bytes.length;
+        markRecoveredRange(
+          progressCoverage,
+          progressTotalBytes,
+          index * header.blockLen,
+          bytes.length,
+        );
       },
     );
     streamKey = identity;
@@ -940,6 +1014,8 @@ function onDecoded(bytes: Uint8Array, box?: SymbolBox, info?: SymbolInfo) {
     startTs = performance.now();
     progressEl.style.display = "block";
     progressStatus.style.display = "flex";
+    resetTransferProgressUi(header.k);
+    progressTotalBytes = header.totalLen;
   }
   minSeq = Math.min(minSeq, header.seq);
   maxSeq = Math.max(maxSeq, header.seq);
@@ -957,12 +1033,12 @@ function onDecoded(bytes: Uint8Array, box?: SymbolBox, info?: SymbolInfo) {
 function updateProgressEstimate() {
   if (!decoder) return;
   const elapsed = Math.max(0, (performance.now() - startTs) / 1000);
-  // Progress runs on frames that carried INFORMATION, not raw arrivals. On a
-  // lossy multi-code run the carousel re-sweeps blocks this receiver already
-  // solved; each re-sweep frame has a fresh seq, so framesNew inflates by the
-  // loss rate — a 30%-catch 4-code run showed 96% on the bar with half the
-  // blocks outstanding, then "finished early". framesRedundant subtracts
-  // exactly those empty arrivals.
+  // ETA runs on frames that carried INFORMATION, not raw arrivals. On a lossy
+  // multi-code run the carousel re-sweeps blocks this receiver already solved;
+  // each re-sweep frame has a fresh seq, so framesNew inflates by the loss
+  // rate — a 30%-catch 4-code run showed 96% on the bar with half the blocks
+  // outstanding, then "finished early". framesRedundant subtracts exactly
+  // those empty arrivals.
   const usefulFrames = decoder.framesNew - decoder.framesRedundant;
   const estimate = estimateTransferProgress(
     decoder.k,
@@ -970,27 +1046,20 @@ function updateProgressEstimate() {
     elapsed,
     decoder.solvedCount,
   );
-  const percent = estimate.fraction * 100;
-  const shownPercent = percent < 10 ? fmtNumber(percent, 1, 1) : fmtNumber(percent, 0);
-  bar.style.width = `${percent.toFixed(1)}%`;
-  progressEl.setAttribute("aria-valuenow", String(Math.floor(percent)));
-  progressLabel.textContent = msg.receive.progressBlocks(
-    shownPercent,
-    fmtInt(decoder.solvedCount),
-    fmtInt(decoder.k),
-  );
   // Held back for the first few frames — a two-frame sample reads wildly wrong.
   const rate =
     decoder.framesNew >= 4
       ? ` · ${msg.units.kbPerSecond(fmtNumber(goodputKbs(elapsed), 1, 1))}`
       : "";
-  etaLabel.textContent =
+  progressSolvedBlocks = decoder.solvedCount;
+  progressTotalBlocks = decoder.k;
+  progressEtaText =
     (estimate.etaSeconds === undefined
       ? estimate.phase === "decoding"
         ? msg.receive.framesDecoding(fmtInt(decoder.framesNew))
         : msg.receive.estimatingTime
-      : msg.receive.aboutEta(formatDurationL(estimate.etaSeconds), fmtInt(decoder.framesNew))) +
-    rate;
+      : msg.receive.aboutEta(formatDurationL(estimate.etaSeconds), fmtInt(decoder.framesNew))) + rate;
+  renderProgressUi(recoveredFraction(progressTotalBytes, progressRecoveredBytes) * 100);
 }
 
 /** Payload KB/s, discounting the frames the fountain spends on overhead. That
@@ -1107,9 +1176,7 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
   // true, so the panel relabels itself as the record of the run it now is.
   const diagnosticsLabel = diagnosticsEl?.querySelector("summary");
   if (diagnosticsLabel) diagnosticsLabel.textContent = msg.receive.transferSummary;
-  bar.style.width = "100%";
-  progressEl.setAttribute("aria-valuenow", "100");
-  etaLabel.textContent = msg.receive.etaTotal(formatDurationL(seconds));
+  finishTransferProgressUi(100, msg.receive.etaTotal(formatDurationL(seconds)));
   try {
     if (!hashOk) throw new OpticalError("streamChecksumMismatch");
     const file = await unpackFile(container);
@@ -1178,8 +1245,8 @@ async function finish(container: Uint8Array, hashOk: boolean, seconds: number) {
     // Everything is already torn down by this point, so the only way back to a
     // live receiver is a reload. Offer it: a failed checksum used to leave the
     // page dead with nothing but an error string on it.
+    finishTransferProgressUi(100, msg.receive.transferFailedShort);
     bar.classList.add("error");
-    etaLabel.textContent = msg.receive.transferFailedShort;
     showError(localizeError(error));
     const heading = document.createElement("div");
     heading.className = "failed";

--- a/receive/main.ts
+++ b/receive/main.ts
@@ -124,6 +124,7 @@ const STATS_WINDOW_MS = 2000;
 
 let stream: MediaStream | null = null;
 let decoder: LTDecoder | null = null;
+let receivedContainer: Uint8Array | null = null;
 let streamKey = "";
 let reportSessionId = 0; // pairs this run with the sender's diagnostics post
 let startTs = 0;
@@ -924,7 +925,16 @@ function onDecoded(bytes: Uint8Array, box?: SymbolBox, info?: SymbolInfo) {
   // just the session id — see the note on it in protocol.ts.
   const identity = streamIdentity(header);
   if (!decoder || streamKey !== identity) {
-    decoder = new LTDecoder(header.k, header.blockLen, header.sessionId, header.totalLen);
+    receivedContainer = new Uint8Array(header.totalLen);
+    decoder = new LTDecoder(
+      header.k,
+      header.blockLen,
+      header.sessionId,
+      header.totalLen,
+      (index, bytes) => {
+        receivedContainer?.set(bytes, index * header.blockLen);
+      },
+    );
     streamKey = identity;
     reportSessionId = header.sessionId;
     startTs = performance.now();
@@ -937,7 +947,7 @@ function onDecoded(bytes: Uint8Array, box?: SymbolBox, info?: SymbolInfo) {
   updateProgressEstimate();
 
   if (decoder.isComplete) {
-    const payload = decoder.assemble()!;
+    const payload = receivedContainer ?? decoder.assemble()!;
     const seconds = (performance.now() - startTs) / 1000;
     const ok = fnv1a(payload) === header.payloadFnv;
     void finish(payload, ok, seconds);

--- a/shared/fountain.ts
+++ b/shared/fountain.ts
@@ -217,6 +217,8 @@ interface PendingFrame {
   words: Uint32Array;
 }
 
+export type SolvedBlockHandler = (index: number, bytes: Uint8Array) => void;
+
 export class LTDecoder {
   private readonly words: number;
   private readonly solved: (Uint32Array | null)[];
@@ -237,6 +239,7 @@ export class LTDecoder {
     readonly blockLen: number,
     readonly sessionId: number,
     readonly totalLen: number,
+    private readonly onSolvedBlock?: SolvedBlockHandler,
   ) {
     this.words = Math.ceil(blockLen / 4);
     this.solved = new Array<Uint32Array | null>(k).fill(null);
@@ -259,9 +262,9 @@ export class LTDecoder {
     const words = new Uint32Array(this.words);
     new Uint8Array(words.buffer).set(block.subarray(0, this.blockLen));
     for (const b of [...idx]) {
-      const s = this.solved[b];
-      if (s) {
-        xorInto(words, s);
+      const solved = this.solved[b];
+      if (solved) {
+        xorInto(words, solved);
         idx.delete(b);
       }
     }
@@ -295,6 +298,8 @@ export class LTDecoder {
       if (this.solved[b]) continue;
       this.solved[b] = w;
       this.solvedCount++;
+      const len = Math.min(this.blockLen, this.totalLen - b * this.blockLen);
+      this.onSolvedBlock?.(b, new Uint8Array(w.buffer, 0, len));
       const waiting = this.byBlock.get(b);
       if (!waiting) continue;
       this.byBlock.delete(b);

--- a/shared/progress.ts
+++ b/shared/progress.ts
@@ -20,6 +20,32 @@ export interface TransferProgressEstimate {
   phase: "collecting" | "decoding";
 }
 
+export function recoveredFraction(totalBytes: number, recoveredBytes: number): number {
+  if (totalBytes <= 0 || recoveredBytes <= 0) return 0;
+  return Math.min(1, recoveredBytes / totalBytes);
+}
+
+export function markRecoveredRange(
+  bins: Float32Array,
+  totalBytes: number,
+  start: number,
+  length: number,
+): void {
+  if (bins.length === 0 || totalBytes <= 0 || length <= 0) return;
+  const from = Math.max(0, start);
+  const to = Math.min(totalBytes, start + length);
+  if (to <= from) return;
+  const first = Math.max(0, Math.floor((from / totalBytes) * bins.length));
+  const last = Math.min(bins.length - 1, Math.ceil((to / totalBytes) * bins.length) - 1);
+  for (let i = first; i <= last; i++) {
+    const binStart = (i / bins.length) * totalBytes;
+    const binEnd = ((i + 1) / bins.length) * totalBytes;
+    const overlap = Math.max(0, Math.min(to, binEnd) - Math.max(from, binStart));
+    if (overlap <= 0) continue;
+    bins[i] = Math.min(1, bins[i]! + overlap / (binEnd - binStart));
+  }
+}
+
 export function estimateTransferProgress(
   sourceBlocks: number,
   uniqueFrames: number,

--- a/shared/style.css
+++ b/shared/style.css
@@ -236,12 +236,13 @@ body.qr-full #stage[hidden] {
   text-align: end;
 }
 .progress > div {
+  width: 100%;
   height: 100%;
-  background: var(--accent);
-  transition: width 0.25s;
+  background: var(--progress-fill, transparent);
+  transition: background-color 0.2s;
 }
 .progress > div.error {
-  background: var(--red);
+  --progress-fill: var(--red);
 }
 /* Styled like the page headings, not green: the status line already says
    "SHA-256 verified ✓", which is what green is reserved for in this palette. */

--- a/tests/fountain.test.ts
+++ b/tests/fountain.test.ts
@@ -367,6 +367,29 @@ test("frames decode in any order", () => {
   assert.deepEqual(decoder.assemble(), payload);
 });
 
+test("solved blocks are written immediately at their final offsets", () => {
+  const byteLength = 50_000;
+  const blockLen = 1445;
+  const payload = testPayload(byteLength);
+  const encoder = new LTEncoder(payload, blockLen, 41);
+  const written: { index: number; bytes: Uint8Array }[] = [];
+  const decoder = new LTDecoder(encoder.k, blockLen, 41, byteLength, (index, bytes) => {
+    written.push({ index, bytes: Uint8Array.from(bytes) });
+  });
+
+  const last = encoder.k - 1;
+  decoder.addFrame(last, encoder.encode(last));
+  assert.equal(decoder.assemble(), null);
+  assert.equal(written.length, 1);
+  assert.equal(written[0]!.index, last);
+  assert.deepEqual(written[0]!.bytes, payload.subarray(last * blockLen));
+
+  decoder.addFrame(0, encoder.encode(0));
+  assert.equal(written.length, 2);
+  assert.equal(written[1]!.index, 0);
+  assert.deepEqual(written[1]!.bytes, payload.subarray(0, blockLen));
+});
+
 test("repeated frames are counted but never corrupt the decode", () => {
   const byteLength = 60_000;
   const blockLen = 1445;

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -4,6 +4,8 @@ import {
   estimateTransferProgress,
   expectedFountainOverhead,
   formatDuration,
+  markRecoveredRange,
+  recoveredFraction,
 } from "../shared/progress.ts";
 
 // k=100 is a ~300 KB file at 2953 bytes/frame — a very ordinary transfer.
@@ -77,4 +79,15 @@ test("durations stay compact and readable", () => {
   assert.equal(formatDuration(12.1), "13s");
   assert.equal(formatDuration(75.1), "1m 16s");
   assert.equal(formatDuration(3_661), "1h 1m");
+});
+
+test("recovered ranges mark their true file positions", () => {
+  const bins = new Float32Array(10);
+  markRecoveredRange(bins, 1000, 400, 100);
+  markRecoveredRange(bins, 1000, 900, 100);
+  assert.deepEqual(
+    [...bins].map((value) => Number(value.toFixed(2))),
+    [0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+  );
+  assert.equal(recoveredFraction(1000, 200), 0.2);
 });


### PR DESCRIPTION
Add a solved-block callback to the fountain decoder and use it on the receive side to place recovered blocks directly into the final container buffer without waiting for sequential assembly.

Also add a regression test that verifies solved blocks are surfaced at their final offsets as soon as they decode.

<!--
Please read this before spending more time on the PR.

Pull requests are considered — selectively, and with a CLA. Two things
decide whether this PR can land:

- **Was there an issue first?** Small, focused fixes are the easiest to
  take. Large features may be declined regardless of quality — open an
  issue before writing code.
- **The CLA.** Every merged contribution needs a signed CLA (the bot will
  prompt below; signing is one comment). See CLA.md for the terms — you
  keep your copyright, and your contribution always remains available
  under the AGPL.

Also welcome:

- **Bug reports**, especially device/browser/camera combinations where the
  receiver fails to decode. There's an issue template for it.
- **Questions** about how any of it works. Open an issue.
- **Forks.** AGPL-3.0-or-later. Build something better on top of it — just keep it open under the same terms.

See CONTRIBUTING.md.
-->
